### PR TITLE
Suggestion: use ConnectorResponseSizeLimitError typed error (re: elastic/kibana#268591)

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -29,3 +29,8 @@ export { normalizeAuthorizationHeaderValue } from './src/auth_types/oauth_authz_
 
 export { ConnectorAuthorizationError, isConnectorAuthorizationError } from './src/errors';
 export type { ConnectorAuthorizationReason } from './src/errors';
+
+export {
+  ConnectorResponseSizeLimitError,
+  isConnectorResponseSizeLimitError,
+} from './src/errors';

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import {
+  ConnectorResponseSizeLimitError,
+  isConnectorResponseSizeLimitError,
+} from './connector_response_size_limit_error';
+
+describe('isConnectorResponseSizeLimitError', () => {
+  it('returns true for a ConnectorResponseSizeLimitError instance', () => {
+    const error = new ConnectorResponseSizeLimitError({
+      message: 'maxContentLength size of 1048576 exceeded',
+      limitBytes: 1048576,
+      contentLengthBytes: 2097152,
+    });
+
+    expect(isConnectorResponseSizeLimitError(error)).toBe(true);
+  });
+
+  it('exposes limitBytes, contentLengthBytes, and estimatedOutputBytes', () => {
+    const error = new ConnectorResponseSizeLimitError({
+      message: 'maxContentLength size of 1048576 exceeded',
+      limitBytes: 1048576,
+      contentLengthBytes: 2097152,
+      estimatedOutputBytes: 2800000,
+    });
+
+    expect(error.limitBytes).toBe(1048576);
+    expect(error.contentLengthBytes).toBe(2097152);
+    expect(error.estimatedOutputBytes).toBe(2800000);
+  });
+
+  it('allows undefined optional fields', () => {
+    const error = new ConnectorResponseSizeLimitError({
+      message: 'maxContentLength size of 1048576 exceeded',
+    });
+
+    expect(error.limitBytes).toBeUndefined();
+    expect(error.contentLengthBytes).toBeUndefined();
+    expect(error.estimatedOutputBytes).toBeUndefined();
+  });
+
+  it('returns true for an Error-like object with matching name (cross-realm)', () => {
+    const crossRealmError = Object.assign(new Error('maxContentLength size of 1048576 exceeded'), {
+      name: 'ConnectorResponseSizeLimitError',
+      limitBytes: 1048576,
+    });
+
+    expect(crossRealmError).not.toBeInstanceOf(ConnectorResponseSizeLimitError);
+    expect(isConnectorResponseSizeLimitError(crossRealmError)).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isConnectorResponseSizeLimitError(new Error('maxContentLength size of 1048576 exceeded'))).toBe(false);
+  });
+
+  it('returns false for a subclassed Error whose name does not match', () => {
+    class SomeOtherError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'SomeOtherError';
+      }
+    }
+
+    expect(isConnectorResponseSizeLimitError(new SomeOtherError('boom'))).toBe(false);
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/connector_response_size_limit_error.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { isError } from 'lodash';
+
+export class ConnectorResponseSizeLimitError extends Error {
+  public readonly limitBytes?: number;
+  public readonly contentLengthBytes?: number;
+  public readonly estimatedOutputBytes?: number;
+
+  constructor({
+    message,
+    limitBytes,
+    contentLengthBytes,
+    estimatedOutputBytes,
+  }: {
+    message: string;
+    limitBytes?: number;
+    contentLengthBytes?: number;
+    estimatedOutputBytes?: number;
+  }) {
+    super(message);
+    this.name = 'ConnectorResponseSizeLimitError';
+    this.limitBytes = limitBytes;
+    this.contentLengthBytes = contentLengthBytes;
+    this.estimatedOutputBytes = estimatedOutputBytes;
+  }
+}
+
+export const isConnectorResponseSizeLimitError = (
+  error: unknown
+): error is ConnectorResponseSizeLimitError =>
+  error instanceof ConnectorResponseSizeLimitError ||
+  (isError(error) && error.name === 'ConnectorResponseSizeLimitError');

--- a/src/platform/packages/shared/kbn-connector-specs/src/errors/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/errors/index.ts
@@ -12,3 +12,8 @@ export {
   isConnectorAuthorizationError,
 } from './connector_authorization_error';
 export type { ConnectorAuthorizationReason } from './connector_authorization_error';
+
+export {
+  ConnectorResponseSizeLimitError,
+  isConnectorResponseSizeLimitError,
+} from './connector_response_size_limit_error';

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
@@ -146,6 +146,8 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 10485760 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: { limitBytes: 10485760 },
     });
 
     const step = {
@@ -175,7 +177,9 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
       errorMeta: {
+        limitBytes: 1024 * 1024,
         contentLengthBytes: 10 * 1024 * 1024,
         estimatedOutputBytes: 14 * 1024 * 1024,
       },
@@ -222,6 +226,8 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: { limitBytes: 1024 * 1024 },
     });
 
     const step = {
@@ -260,7 +266,9 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
       errorMeta: {
+        limitBytes: 1024 * 1024,
         contentLengthBytes: 10 * 1024 * 1024,
         estimatedOutputBytes: 14 * 1024 * 1024,
       },
@@ -302,7 +310,8 @@ describe('ConnectorStepImpl', () => {
       status: 'error',
       message: null,
       serviceMessage: 'maxContentLength size of 1048576 exceeded',
-      errorMeta: { contentLengthBytes: 10 * 1024 * 1024 },
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: { limitBytes: 1024 * 1024, contentLengthBytes: 10 * 1024 * 1024 },
     });
 
     const step = {

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.test.ts
@@ -332,6 +332,84 @@ describe('ConnectorStepImpl', () => {
     });
   });
 
+  it('detects response size limit via errorName (typed path) for spec connector without max-step-size', async () => {
+    const { stepExecutionRuntime, connectorExecutor, workflowRuntime, workflowLogger } =
+      createMocks();
+
+    // This is what action_executor.ts produces when it catches ConnectorResponseSizeLimitError
+    connectorExecutor.execute.mockResolvedValue({
+      status: 'error',
+      message: 'an error occurred while running the action',
+      serviceMessage: 'maxContentLength size of 1048576 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: {
+        limitBytes: 1048576,
+        contentLengthBytes: 10 * 1024 * 1024,
+        estimatedOutputBytes: 14 * 1024 * 1024,
+      },
+    });
+
+    const step = {
+      name: 'download_file',
+      stepId: 'download_file',
+      type: 'google_drive.downloadFile',
+      'connector-id': 'conn-123',
+    };
+
+    const impl = new ConnectorStepImpl(
+      step,
+      stepExecutionRuntime as any,
+      connectorExecutor as any,
+      workflowRuntime as any,
+      workflowLogger as any
+    );
+
+    const result = await (impl as any)._run({});
+    expect(result.error.type).toBe('ActionsResponseContentLengthExceeded');
+    expect(result.error.details).toEqual({
+      configKey: 'xpack.actions.maxResponseContentLength',
+      limitBytes: 1048576,
+      contentLengthBytes: 10 * 1024 * 1024,
+      estimatedOutputBytes: 14 * 1024 * 1024,
+      suggestedLimitBytes: 14 * 1024 * 1024,
+    });
+  });
+
+  it('uses limitBytes from errorMeta (typed path) instead of parsing the message', async () => {
+    const { stepExecutionRuntime, connectorExecutor, workflowRuntime, workflowLogger } =
+      createMocks();
+
+    connectorExecutor.execute.mockResolvedValue({
+      status: 'error',
+      message: 'an error occurred while running the action',
+      serviceMessage: 'maxContentLength size of 999 exceeded',
+      errorName: 'ConnectorResponseSizeLimitError',
+      errorMeta: {
+        limitBytes: 2097152,
+      },
+    });
+
+    const step = {
+      name: 'download_file',
+      stepId: 'download_file',
+      type: 'google_drive.downloadFile',
+      'connector-id': 'conn-123',
+    };
+
+    const impl = new ConnectorStepImpl(
+      step,
+      stepExecutionRuntime as any,
+      connectorExecutor as any,
+      workflowRuntime as any,
+      workflowLogger as any
+    );
+
+    const result = await (impl as any)._run({});
+    expect(result.error.type).toBe('ActionsResponseContentLengthExceeded');
+    // limitBytes should come from errorMeta (2MB), not from parsing the message (999)
+    expect(result.error.details.limitBytes).toBe(2097152);
+  });
+
   it('throws when connectorExecutor is undefined', async () => {
     const { stepExecutionRuntime, workflowRuntime, workflowLogger } = createMocks();
 

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
@@ -29,16 +29,9 @@ import type { IWorkflowEventLogger } from '../workflow_event_logger';
  */
 const CONNECTOR_TYPES_WITH_LAYER_1 = new Set<string>(['http']);
 
-// Fallback pattern for non-spec connectors (e.g. http) that still surface the raw
-// Axios message instead of a typed ConnectorResponseSizeLimitError.
-const ACTIONS_MAX_CONTENT_LENGTH_ERROR_PATTERN = /maxContentLength size of (\d+) exceeded/;
-
-const getActionsMaxContentLengthLimit = (errorMessage: string): number | undefined => {
-  const match = errorMessage.match(ACTIONS_MAX_CONTENT_LENGTH_ERROR_PATTERN);
-  return match ? Number(match[1]) : undefined;
-};
-
-const getLimitBytesFromErrorMeta = (errorMeta: Record<string, unknown> | undefined): number | undefined => {
+const getLimitBytesFromErrorMeta = (
+  errorMeta: Record<string, unknown> | undefined
+): number | undefined => {
   const v = errorMeta?.limitBytes;
   return typeof v === 'number' ? v : undefined;
 };
@@ -201,16 +194,11 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
       } else {
         const errorMsg = serviceMessage ?? message ?? 'Unknown error';
 
-        // Typed path: spec connectors throw ConnectorResponseSizeLimitError, which
-        // action_executor.ts converts to errorName + structured errorMeta.
-        // Fallback path: non-spec connectors (e.g. http) still surface the raw Axios message.
-        const isResponseSizeLimitError =
-          errorName === 'ConnectorResponseSizeLimitError' || errorMsg.includes('maxContentLength');
+        const isResponseSizeLimitError = errorName === 'ConnectorResponseSizeLimitError';
 
         if (isResponseSizeLimitError) {
           if (!usesWorkflowTransportLimit) {
-            const limitBytes =
-              getLimitBytesFromErrorMeta(errorMeta) ?? getActionsMaxContentLengthLimit(errorMsg);
+            const limitBytes = getLimitBytesFromErrorMeta(errorMeta);
             return {
               input: withInputs,
               output: undefined,

--- a/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
+++ b/src/platform/plugins/shared/workflows_execution_engine/server/step/connector_step.ts
@@ -29,16 +29,18 @@ import type { IWorkflowEventLogger } from '../workflow_event_logger';
  */
 const CONNECTOR_TYPES_WITH_LAYER_1 = new Set<string>(['http']);
 
-// Axios internal error message format — no typed error code is exposed for this case,
-// so regex matching is the only reliable detection method.
+// Fallback pattern for non-spec connectors (e.g. http) that still surface the raw
+// Axios message instead of a typed ConnectorResponseSizeLimitError.
 const ACTIONS_MAX_CONTENT_LENGTH_ERROR_PATTERN = /maxContentLength size of (\d+) exceeded/;
 
 const getActionsMaxContentLengthLimit = (errorMessage: string): number | undefined => {
   const match = errorMessage.match(ACTIONS_MAX_CONTENT_LENGTH_ERROR_PATTERN);
-  if (!match) {
-    return undefined;
-  }
-  return Number(match[1]);
+  return match ? Number(match[1]) : undefined;
+};
+
+const getLimitBytesFromErrorMeta = (errorMeta: Record<string, unknown> | undefined): number | undefined => {
+  const v = errorMeta?.limitBytes;
+  return typeof v === 'number' ? v : undefined;
 };
 
 const getContentLengthBytes = (
@@ -188,7 +190,7 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
         }
       }
 
-      const { data, status, message, serviceMessage, errorMeta } = output;
+      const { data, status, message, serviceMessage, errorMeta, errorName } = output;
 
       if (status === 'ok') {
         return {
@@ -199,9 +201,16 @@ export class ConnectorStepImpl extends BaseAtomicNodeImplementation<ConnectorSte
       } else {
         const errorMsg = serviceMessage ?? message ?? 'Unknown error';
 
-        if (errorMsg.includes('maxContentLength')) {
+        // Typed path: spec connectors throw ConnectorResponseSizeLimitError, which
+        // action_executor.ts converts to errorName + structured errorMeta.
+        // Fallback path: non-spec connectors (e.g. http) still surface the raw Axios message.
+        const isResponseSizeLimitError =
+          errorName === 'ConnectorResponseSizeLimitError' || errorMsg.includes('maxContentLength');
+
+        if (isResponseSizeLimitError) {
           if (!usesWorkflowTransportLimit) {
-            const limitBytes = getActionsMaxContentLengthLimit(errorMsg);
+            const limitBytes =
+              getLimitBytesFromErrorMeta(errorMeta) ?? getActionsMaxContentLengthLimit(errorMsg);
             return {
               input: withInputs,
               output: undefined,

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.test.ts
@@ -31,7 +31,7 @@ import { finished } from 'stream/promises';
 import { PassThrough } from 'stream';
 import { TaskErrorSource } from '@kbn/task-manager-plugin/common';
 import { createTaskRunError, getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
-import { ConnectorAuthorizationError } from '@kbn/connector-specs';
+import { ConnectorAuthorizationError, ConnectorResponseSizeLimitError } from '@kbn/connector-specs';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import type { ConnectorRateLimiter } from './connector_rate_limiter';
 import { createMockInMemoryConnector } from '../application/connector/mocks';
@@ -1557,6 +1557,44 @@ describe('Action Executor', () => {
       expect(loggerMock.error).toBeCalledWith(err, {
         error: { stack_trace: 'foo error\n  stack 1\n  stack 2\n  stack 3' },
         tags: ['test', '1', 'action-run-failed', 'user-error'],
+      });
+    });
+
+    test(`${label} returns structured error result when executor throws ConnectorResponseSizeLimitError`, async () => {
+      const err = new ConnectorResponseSizeLimitError({
+        message: 'maxContentLength size of 1048576 exceeded',
+        limitBytes: 1048576,
+        contentLengthBytes: 10 * 1024 * 1024,
+        estimatedOutputBytes: 14 * 1024 * 1024,
+      });
+      (
+        connectorType.executor as jest.MockedFunction<NonNullable<ConnectorType['executor']>>
+      ).mockRejectedValueOnce(err);
+      encryptedSavedObjectsClient.getDecryptedAsInternalUser.mockResolvedValueOnce(
+        connectorSavedObject
+      );
+      connectorTypeRegistry.get.mockReturnValueOnce(connectorType);
+
+      let executorResult;
+      if (executeUnsecure) {
+        executorResult = await actionExecutor.executeUnsecured(executeUnsecuredParams);
+      } else {
+        executorResult = await actionExecutor.execute(executeParams);
+      }
+
+      expect(executorResult).toEqual({
+        actionId: CONNECTOR_ID,
+        status: 'error',
+        message: 'an error occurred while running the action',
+        serviceMessage: 'maxContentLength size of 1048576 exceeded',
+        errorName: 'ConnectorResponseSizeLimitError',
+        errorMeta: {
+          limitBytes: 1048576,
+          contentLengthBytes: 10 * 1024 * 1024,
+          estimatedOutputBytes: 14 * 1024 * 1024,
+        },
+        retry: false,
+        errorSource: TaskErrorSource.USER,
       });
     });
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/action_executor.ts
@@ -21,7 +21,7 @@ import type { IEventLogger } from '@kbn/event-log-plugin/server';
 import { SAVED_OBJECT_REL_PRIMARY } from '@kbn/event-log-plugin/server';
 import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
 import { getErrorSource as getTaskManagerErrorSource } from '@kbn/task-manager-plugin/server/task_running';
-import { isConnectorAuthorizationError } from '@kbn/connector-specs';
+import { isConnectorAuthorizationError, isConnectorResponseSizeLimitError } from '@kbn/connector-specs';
 import { GEN_AI_TOKEN_COUNT_EVENT } from './event_based_telemetry';
 import { ConnectorUsageCollector } from '../usage/connector_usage_collector';
 import {
@@ -595,6 +595,26 @@ export class ActionExecutor {
                 connectorName: name,
                 authMethod: err.authMethod,
                 reason: err.reason,
+              },
+              error: err,
+              retry: false,
+              errorSource: TaskErrorSource.USER,
+            };
+          } else if (isConnectorResponseSizeLimitError(err)) {
+            rawResult = {
+              actionId,
+              status: 'error',
+              message: 'an error occurred while running the action',
+              serviceMessage: err.message,
+              errorName: 'ConnectorResponseSizeLimitError',
+              errorMeta: {
+                ...(err.limitBytes !== undefined ? { limitBytes: err.limitBytes } : {}),
+                ...(err.contentLengthBytes !== undefined
+                  ? { contentLengthBytes: err.contentLengthBytes }
+                  : {}),
+                ...(err.estimatedOutputBytes !== undefined
+                  ? { estimatedOutputBytes: err.estimatedOutputBytes }
+                  : {}),
               },
               error: err,
               retry: false,

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.test.ts
@@ -17,6 +17,7 @@ import { requestOAuthClientCredentialsToken } from './request_oauth_client_crede
 import { getOAuthAuthorizationCodeAccessToken } from './get_oauth_authorization_code_access_token';
 import { PFX } from '@kbn/connector-specs/src/auth_types/pfx';
 import type { NormalizedAuthType } from '@kbn/connector-specs';
+import { ConnectorResponseSizeLimitError } from '@kbn/connector-specs';
 
 jest.mock('./get_custom_agents', () => ({
   getCustomAgents: jest.fn().mockReturnValue({
@@ -96,10 +97,12 @@ describe('getAxiosInstance', () => {
 
     const error = new Error('maxContentLength size of 20971520 exceeded') as Error & {
       code?: string;
+      config?: { maxContentLength?: number };
       response?: { status?: number; headers?: Record<string, string> };
       request?: { res?: { headers?: Record<string, string> } };
     };
     error.code = 'ERR_BAD_RESPONSE';
+    error.config = { maxContentLength: 20 * 1024 * 1024 };
     error.response = {
       status: 200,
       headers: {
@@ -120,7 +123,11 @@ describe('getAxiosInstance', () => {
 
     // @ts-expect-error accessing internal axios interceptor handlers
     const rejectionHandler = result!.interceptors.response.handlers[0].rejected as Function;
-    await expect(rejectionHandler(error)).rejects.toBe(error);
+    await expect(rejectionHandler(error)).rejects.toBeInstanceOf(ConnectorResponseSizeLimitError);
+    await expect(rejectionHandler(error)).rejects.toMatchObject({
+      limitBytes: 20 * 1024 * 1024,
+      contentLengthBytes: 104857600,
+    });
 
     expect(logger.debug).toHaveBeenCalledWith(
       'Actions Axios request exceeded maxContentLength: maxContentLength size of 20971520 exceeded; metadata: {"connectorId":"1","configuredMaxContentLength":20971520,"errorCode":"ERR_BAD_RESPONSE","responseStatus":200,"responseContentLength":"104857600","requestResponseContentLength":"104857600","responseHeaderKeys":["content-length","content-type","set-cookie"],"requestResponseHeaderKeys":["Content-Length","server","cookie"],"responseHeaders":{"content-length":"104857600","content-type":"application/octet-stream","set-cookie":"[REDACTED]"},"requestResponseHeaders":{"Content-Length":"104857600","server":"test","cookie":"[REDACTED]"}}'

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
@@ -14,6 +14,10 @@ import type {
 import axios from 'axios';
 import type { Logger } from '@kbn/core/server';
 import type { AuthMode, GetTokenOpts } from '@kbn/connector-specs';
+import {
+  ConnectorResponseSizeLimitError,
+  getResponseContentLengthBytes,
+} from '@kbn/connector-specs';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { ActionInfo } from './action_executor';
 import type { AuthTypeRegistry } from '../auth_types';
@@ -48,7 +52,6 @@ interface GetAxiosInstanceOpts {
 
 type ValidatedSecrets = Record<string, unknown>;
 
-const MAX_CONTENT_LENGTH_ERROR_MESSAGE = 'maxContentLength';
 const SENSITIVE_HEADER_NAMES = new Set([
   'authorization',
   'cookie',
@@ -110,10 +113,6 @@ const logMaxContentLengthError = ({
   maxContentLength: number;
 }) => {
   const errorMessage = error instanceof Error ? error.message : String(error);
-  if (!errorMessage.includes(MAX_CONTENT_LENGTH_ERROR_MESSAGE)) {
-    return;
-  }
-
   const axiosError = error as AxiosError & {
     request?: {
       res?: {
@@ -252,12 +251,34 @@ export const getAxiosInstanceWithAuth = ({
         secrets
       );
       configuredAxiosInstance.interceptors.response.use(undefined, (error: unknown) => {
-        logMaxContentLengthError({
-          connectorId,
-          error,
-          logger,
-          maxContentLength: configuredMaxContentLength,
-        });
+        const axiosError = error as {
+          code?: string;
+          config?: { maxContentLength?: number };
+          response?: unknown;
+          request?: unknown;
+        };
+        if (
+          configuredMaxContentLength > 0 &&
+          axiosError.code === 'ERR_BAD_RESPONSE' &&
+          axiosError.config?.maxContentLength === configuredMaxContentLength
+        ) {
+          logMaxContentLengthError({
+            connectorId,
+            error,
+            logger,
+            maxContentLength: configuredMaxContentLength,
+          });
+          const sizeLimitError = new ConnectorResponseSizeLimitError({
+            message: error instanceof Error ? error.message : String(error),
+            limitBytes: configuredMaxContentLength,
+            contentLengthBytes: getResponseContentLengthBytes(error),
+          });
+          Object.assign(sizeLimitError, {
+            response: axiosError.response,
+            request: axiosError.request,
+          });
+          return Promise.reject(sizeLimitError);
+        }
         return Promise.reject(error);
       });
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -8,7 +8,10 @@
 import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
 import { generateExecutorFunction } from './generate_executor_function';
-import { setConnectorActionErrorMeta } from '@kbn/connector-specs';
+import {
+  ConnectorResponseSizeLimitError,
+  setConnectorActionErrorMeta,
+} from '@kbn/connector-specs';
 import type { ConnectorSpec } from '@kbn/connector-specs';
 import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
 
@@ -232,7 +235,7 @@ describe('generateExecutorFunction', () => {
       });
     });
 
-    it('includes content-length from Axios error response headers', async () => {
+    it('throws ConnectorResponseSizeLimitError with content-length from Axios error response headers', async () => {
       const error = new Error('maxContentLength size of 1048576 exceeded') as Error & {
         response?: { headers?: Record<string, string> };
       };
@@ -244,15 +247,13 @@ describe('generateExecutorFunction', () => {
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
       });
 
-      const result = await executor(
-        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
-      );
-
-      expect(result).toEqual({
-        status: 'error',
+      await expect(
+        executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }))
+      ).rejects.toMatchObject({
+        name: 'ConnectorResponseSizeLimitError',
         message: 'maxContentLength size of 1048576 exceeded',
-        actionId: connectorId,
-        errorMeta: { contentLengthBytes: 10 * 1024 * 1024 },
+        limitBytes: 1048576,
+        contentLengthBytes: 10 * 1024 * 1024,
       });
     });
 
@@ -275,19 +276,16 @@ describe('generateExecutorFunction', () => {
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
       });
 
-      const result = await executor(
-        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
-      );
-
-      expect(result).toEqual({
-        status: 'error',
-        message: 'maxContentLength size of 1048576 exceeded',
-        actionId: connectorId,
-        errorMeta: { contentLengthBytes: 2048 },
+      await expect(
+        executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }))
+      ).rejects.toMatchObject({
+        name: 'ConnectorResponseSizeLimitError',
+        limitBytes: 1048576,
+        contentLengthBytes: 2048,
       });
     });
 
-    it('merges connector-provided error metadata with Axios header metadata', async () => {
+    it('connector-provided metadata takes precedence over header-derived contentLengthBytes', async () => {
       const error = new Error('maxContentLength size of 1048576 exceeded') as Error & {
         response?: { headers?: Record<string, string> };
       };
@@ -303,19 +301,27 @@ describe('generateExecutorFunction', () => {
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
       });
 
-      const result = await executor(
-        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
-      );
-
-      expect(result).toEqual({
-        status: 'error',
-        message: 'maxContentLength size of 1048576 exceeded',
-        actionId: connectorId,
-        errorMeta: {
-          contentLengthBytes: 20 * 1024 * 1024,
-          estimatedOutputBytes: 28 * 1024 * 1024,
-        },
+      await expect(
+        executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }))
+      ).rejects.toMatchObject({
+        name: 'ConnectorResponseSizeLimitError',
+        limitBytes: 1048576,
+        contentLengthBytes: 20 * 1024 * 1024,
+        estimatedOutputBytes: 28 * 1024 * 1024,
       });
+    });
+
+    it('throws ConnectorResponseSizeLimitError and is an instance of the class', async () => {
+      mockHandler.mockRejectedValue(new Error('maxContentLength size of 1048576 exceeded'));
+
+      const executor = generateExecutorFunction({
+        actions: makeActions(),
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+      });
+
+      await expect(
+        executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }))
+      ).rejects.toBeInstanceOf(ConnectorResponseSizeLimitError);
     });
 
     it('logs the error message when the handler throws', async () => {

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -236,10 +236,11 @@ describe('generateExecutorFunction', () => {
     });
 
     it('throws ConnectorResponseSizeLimitError with content-length from Axios error response headers', async () => {
-      const error = new Error('maxContentLength size of 1048576 exceeded') as Error & {
-        response?: { headers?: Record<string, string> };
-      };
-      error.response = { headers: { 'content-length': '10485760' } };
+      const error = new ConnectorResponseSizeLimitError({
+        message: 'maxContentLength size of 1048576 exceeded',
+        limitBytes: 1048576,
+      });
+      Object.assign(error, { response: { headers: { 'content-length': '10485760' } } });
       mockHandler.mockRejectedValue(error);
 
       const executor = generateExecutorFunction({
@@ -258,10 +259,11 @@ describe('generateExecutorFunction', () => {
     });
 
     it('uses action responseSizeHeader when extracting Axios error response size', async () => {
-      const error = new Error('maxContentLength size of 1048576 exceeded') as Error & {
-        request?: { res?: { headers?: Record<string, string> } };
-      };
-      error.request = { res: { headers: { 'x-resource-size': '2048' } } };
+      const error = new ConnectorResponseSizeLimitError({
+        message: 'maxContentLength size of 1048576 exceeded',
+        limitBytes: 1048576,
+      });
+      Object.assign(error, { request: { res: { headers: { 'x-resource-size': '2048' } } } });
       mockHandler.mockRejectedValue(error);
 
       const executor = generateExecutorFunction({
@@ -286,10 +288,11 @@ describe('generateExecutorFunction', () => {
     });
 
     it('connector-provided metadata takes precedence over header-derived contentLengthBytes', async () => {
-      const error = new Error('maxContentLength size of 1048576 exceeded') as Error & {
-        response?: { headers?: Record<string, string> };
-      };
-      error.response = { headers: { 'content-length': '10485760' } };
+      const error = new ConnectorResponseSizeLimitError({
+        message: 'maxContentLength size of 1048576 exceeded',
+        limitBytes: 1048576,
+      });
+      Object.assign(error, { response: { headers: { 'content-length': '10485760' } } });
       setConnectorActionErrorMeta(error, {
         contentLengthBytes: 20 * 1024 * 1024,
         estimatedOutputBytes: 28 * 1024 * 1024,
@@ -312,7 +315,12 @@ describe('generateExecutorFunction', () => {
     });
 
     it('throws ConnectorResponseSizeLimitError and is an instance of the class', async () => {
-      mockHandler.mockRejectedValue(new Error('maxContentLength size of 1048576 exceeded'));
+      mockHandler.mockRejectedValue(
+        new ConnectorResponseSizeLimitError({
+          message: 'maxContentLength size of 1048576 exceeded',
+          limitBytes: 1048576,
+        })
+      );
 
       const executor = generateExecutorFunction({
         actions: makeActions(),

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -8,6 +8,7 @@
 import type { ConnectorSpec } from '@kbn/connector-specs';
 import {
   ConnectorResponseSizeLimitError,
+  isConnectorResponseSizeLimitError,
   getConnectorActionErrorMeta,
   getFinitePositiveNumber,
   getHeaderValue,
@@ -25,7 +26,6 @@ interface FetcherOptions {
 }
 
 const DEFAULT_RESPONSE_SIZE_HEADER = 'content-length';
-const MAX_CONTENT_LENGTH_ERROR_PATTERN = /maxContentLength size of (\d+) exceeded/;
 
 const getResponseSizeHeaderBytes = ({
   error,
@@ -44,11 +44,6 @@ const getResponseSizeHeaderBytes = ({
     getHeaderValue({ headers: axiosError.request?.res?.headers, headerName });
 
   return getFinitePositiveNumber(Array.isArray(headerValue) ? headerValue[0] : headerValue);
-};
-
-const parseMaxContentLengthLimit = (message: string): number | undefined => {
-  const match = message.match(MAX_CONTENT_LENGTH_ERROR_PATTERN);
-  return match ? Number(match[1]) : undefined;
 };
 
 export const generateExecutorFunction = ({
@@ -113,8 +108,7 @@ export const generateExecutorFunction = ({
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
 
-      if (MAX_CONTENT_LENGTH_ERROR_PATTERN.test(errorMessage)) {
-        const limitBytes = parseMaxContentLengthLimit(errorMessage);
+      if (isConnectorResponseSizeLimitError(error)) {
         const contentLengthBytes = getResponseSizeHeaderBytes({
           error,
           headerName: actions[subAction].responseSizeHeader ?? DEFAULT_RESPONSE_SIZE_HEADER,
@@ -123,8 +117,8 @@ export const generateExecutorFunction = ({
         // Connector-provided metadata (e.g. file size from provider API) takes
         // precedence over generic header-derived values.
         throw new ConnectorResponseSizeLimitError({
-          message: errorMessage,
-          limitBytes,
+          message: error.message,
+          limitBytes: error.limitBytes,
           contentLengthBytes: connectorMeta?.contentLengthBytes ?? contentLengthBytes,
           estimatedOutputBytes: connectorMeta?.estimatedOutputBytes,
         });

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -7,6 +7,7 @@
 
 import type { ConnectorSpec } from '@kbn/connector-specs';
 import {
+  ConnectorResponseSizeLimitError,
   getConnectorActionErrorMeta,
   getFinitePositiveNumber,
   getHeaderValue,
@@ -24,6 +25,7 @@ interface FetcherOptions {
 }
 
 const DEFAULT_RESPONSE_SIZE_HEADER = 'content-length';
+const MAX_CONTENT_LENGTH_ERROR_PATTERN = /maxContentLength size of (\d+) exceeded/;
 
 const getResponseSizeHeaderBytes = ({
   error,
@@ -44,22 +46,9 @@ const getResponseSizeHeaderBytes = ({
   return getFinitePositiveNumber(Array.isArray(headerValue) ? headerValue[0] : headerValue);
 };
 
-const getErrorMeta = ({
-  error,
-  contentLengthBytes,
-}: {
-  error: unknown;
-  contentLengthBytes?: number;
-}): Record<string, unknown> | undefined => {
-  const connectorActionErrorMeta = getConnectorActionErrorMeta(error);
-  // Connector-provided metadata (e.g. file size from provider API) takes
-  // precedence over generic header-derived values.
-  const errorMeta = {
-    ...(contentLengthBytes !== undefined ? { contentLengthBytes } : {}),
-    ...connectorActionErrorMeta,
-  };
-
-  return Object.keys(errorMeta).length > 0 ? errorMeta : undefined;
+const parseMaxContentLengthLimit = (message: string): number | undefined => {
+  const match = message.match(MAX_CONTENT_LENGTH_ERROR_PATTERN);
+  return match ? Number(match[1]) : undefined;
 };
 
 export const generateExecutorFunction = ({
@@ -123,17 +112,29 @@ export const generateExecutorFunction = ({
       return { status: 'ok', data, actionId: connectorId };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
-      const contentLengthBytes = getResponseSizeHeaderBytes({
-        error,
-        headerName: actions[subAction].responseSizeHeader ?? DEFAULT_RESPONSE_SIZE_HEADER,
-      });
-      const errorMeta = getErrorMeta({ error, contentLengthBytes });
+
+      if (MAX_CONTENT_LENGTH_ERROR_PATTERN.test(errorMessage)) {
+        const limitBytes = parseMaxContentLengthLimit(errorMessage);
+        const contentLengthBytes = getResponseSizeHeaderBytes({
+          error,
+          headerName: actions[subAction].responseSizeHeader ?? DEFAULT_RESPONSE_SIZE_HEADER,
+        });
+        const connectorMeta = getConnectorActionErrorMeta(error);
+        // Connector-provided metadata (e.g. file size from provider API) takes
+        // precedence over generic header-derived values.
+        throw new ConnectorResponseSizeLimitError({
+          message: errorMessage,
+          limitBytes,
+          contentLengthBytes: connectorMeta?.contentLengthBytes ?? contentLengthBytes,
+          estimatedOutputBytes: connectorMeta?.estimatedOutputBytes,
+        });
+      }
+
       logger.error(`error on ${connectorId} event: ${errorMessage}`);
       return {
         status: 'error',
         message: errorMessage,
         actionId: connectorId,
-        ...(errorMeta ? { errorMeta } : {}),
       };
     }
   };


### PR DESCRIPTION
## Context

This is a suggestion for [elastic/kibana#268591](https://github.com/elastic/kibana/pull/268591) showing what the `ConnectorAuthorizationError` pattern would look like applied to the response size limit case.

## What this adds

- **`ConnectorResponseSizeLimitError`** in `kbn-connector-specs` — a typed error with explicit `limitBytes`, `contentLengthBytes`, and `estimatedOutputBytes` fields, following the same shape as `ConnectorAuthorizationError`. Also adds a WeakMap-based `setConnectorActionErrorMeta`/`getConnectorActionErrorMeta` API so connector actions can annotate errors with provider-specific size hints before the executor processes them.
- **`responseSizeHeader`** on `ActionDefinition` — lets a connector declare which HTTP response header advertises the response size (defaults to `content-length`). The generated executor reads this header when a size-limit error occurs.
- **`get_axios_instance.ts`** — adds an Axios response interceptor that converts `ERR_BAD_RESPONSE` errors into `ConnectorResponseSizeLimitError` at the point the HTTP client aborts the stream.
- **`generate_executor_function.ts`** — catches `ConnectorResponseSizeLimitError` from the interceptor and rethrows it enriched with connector-specific metadata: the connector's declared `responseSizeHeader` value and any WeakMap-annotated hints from the action handler (e.g. Jina's `x-decompressed-content-length`).
- **`action_executor.ts`** — handles `ConnectorResponseSizeLimitError` in the catch block (parallel to the existing `isConnectorAuthorizationError` branch), serializing it into the action result as `errorName: 'ConnectorResponseSizeLimitError'` and structured `errorMeta`.
- **`ActionsResponseContentLengthLimitError`** in the workflow layer — a new `ExecutionError` subtype for when the Actions HTTP limit fires before the workflow step can enforce `max-step-size`. Gives actionable guidance including whether raising `max-step-size` would also raise the connector request limit.
- **`connector_step.ts`** — replaces the `errorMsg.includes('maxContentLength')` string-match with `errorName === 'ConnectorResponseSizeLimitError'` as the primary detection path. Routes to `ResponseSizeLimitError` when the workflow transport limit applies (i.e. `http` type, or spec connector with `max-step-size`), or to `ActionsResponseContentLengthLimitError` when the actions HTTP limit fired before the workflow could apply its own limit.
- **`ResponseSizeLimitError`** — extended to accept and surface `contentLengthBytes` and `estimatedOutputBytes` in the error message and `details`, including a suggested `max-step-size` value when one can be derived.

## What this changes vs. the original PR

The cross-layer contract (actions plugin → workflow step) becomes explicit and typed instead of an untyped `Record<string, unknown>` bag detected by string-matching an internal Axios message. The old `errorMsg.includes('maxContentLength')` check is removed entirely; detection is now driven by `errorName`.
