### PR TITLE
Multi-client architecture framework (issue #275613)

### DIFF
--- a/src/platform/packages/shared/kbn-connector-specs/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/index.ts
@@ -41,3 +41,12 @@ export type { ConnectorAuthorizationReason } from './src/errors';
 export { AUTH_MODE_BY_AUTH_TYPE_ID } from './src/auth_mode_by_auth_type_id';
 export { getMeta, setMeta, addMeta } from './src/connector_spec_ui';
 export type { BaseMetadata } from './src/connector_spec_ui';
+export { clientTypes } from './src/lib/clients';
+export type {
+  ClientTypeSpec,
+  BuildContext,
+  ConnectorNetwork,
+  CredentialAccessor,
+  ClientRegistry,
+  ClientTypeId,
+} from './src/lib/clients';

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AuthContext } from '../connector_spec';
+import { BearerAuth } from './bearer';
+
+describe('BearerAuth', () => {
+  it('getAuthHeaders returns the bearer Authorization header', async () => {
+    const mockCtx: AuthContext = {
+      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as never,
+      getCustomHostSettings: () => undefined,
+      getToken: async () => null,
+      sslSettings: {} as never,
+    };
+
+    const headers = await BearerAuth.getAuthHeaders?.(mockCtx, { token: 'my-secret-token' });
+
+    expect(headers).toEqual({ Authorization: 'Bearer my-secret-token' });
+  });
+});

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.test.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.test.ts
@@ -7,20 +7,25 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import { loggerMock } from '@kbn/logging-mocks';
 import type { AuthContext } from '../connector_spec';
 import { BearerAuth } from './bearer';
 
+const mockAuthContext: AuthContext = {
+  getCustomHostSettings: () => undefined,
+  getToken: async () => null,
+  logger: loggerMock.create(),
+  sslSettings: {},
+};
+
 describe('BearerAuth', () => {
-  it('getAuthHeaders returns the bearer Authorization header', async () => {
-    const mockCtx: AuthContext = {
-      logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() } as never,
-      getCustomHostSettings: () => undefined,
-      getToken: async () => null,
-      sslSettings: {} as never,
-    };
-
-    const headers = await BearerAuth.getAuthHeaders?.(mockCtx, { token: 'my-secret-token' });
-
-    expect(headers).toEqual({ Authorization: 'Bearer my-secret-token' });
+  describe('getAuthHeaders', () => {
+    it('returns Authorization header with bearer token', async () => {
+      const { getAuthHeaders } = BearerAuth;
+      if (!getAuthHeaders) throw new Error('BearerAuth.getAuthHeaders is not defined');
+      await expect(getAuthHeaders(mockAuthContext, { token: 'tok' })).resolves.toEqual({
+        Authorization: 'Bearer tok',
+      });
+    });
   });
 });

--- a/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/auth_types/bearer.ts
@@ -42,4 +42,10 @@ export const BearerAuth: AuthTypeSpec<AuthSchemaType> = {
 
     return axiosInstance;
   },
+  getAuthHeaders: async (
+    _: AuthContext,
+    secret: AuthSchemaType
+  ): Promise<Record<string, string>> => {
+    return { Authorization: `Bearer ${secret.token}` };
+  },
 };

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -26,6 +26,7 @@ import type { Logger } from '@kbn/logging';
 import type { CustomHostSettings, ProxySettings, SSLSettings } from '@kbn/actions-utils';
 import type { LicenseType } from '@kbn/licensing-types';
 import type { AxiosHeaderValue, AxiosInstance } from 'axios';
+import type { ClientRegistry, ClientTypeId } from './lib/clients';
 
 export { UISchemas } from './connector_spec_ui';
 
@@ -133,6 +134,7 @@ export interface AuthTypeSpec<T extends Record<string, unknown>> {
   normalizeSchema?: (defaults?: Record<string, unknown>) => z.ZodObject<Record<string, z.ZodType>>;
   configure: (ctx: AuthContext, axiosInstance: AxiosInstance, secret: T) => Promise<AxiosInstance>;
   authMode?: AuthMode;
+  getAuthHeaders?(ctx: AuthContext, secret: T): Promise<Record<string, string>>;
 }
 
 export type NormalizedAuthType = AuthTypeSpec<Record<string, unknown>>;
@@ -233,6 +235,11 @@ export interface ActionContext {
   connectorUsageCollector?: unknown;
   log: Logger;
   secrets?: Record<string, unknown>;
+  /**
+   * Resolves a client for the given client type id, building and leasing it
+   * on first use and reusing it for the lifetime of the lease.
+   */
+  getClient: <K extends ClientTypeId>(id: K) => Promise<ClientRegistry[K]>;
 }
 
 // ============================================================================

--- a/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/connector_spec.ts
@@ -231,15 +231,20 @@ export interface ActionDefinition<TInput = unknown, TOutput = unknown, TError = 
 
 export interface ActionContext {
   client: AxiosInstance;
+  /**
+   * Leases a pooled, ready-to-use client by id. The connection is built on the
+   * first request for a given connector and reused across calls. Building is an
+   * async, side-effecting operation, so this is an explicit call (not a property)
+   * and only the client types a handler actually asks for are ever built.
+   *
+   * PoC: replaces per-handler `withMcpClient` connect/disconnect; lifetime is governed
+   * by LeasePool on the actions plugin, not the action stack frame.
+   */
+  getClient: <K extends ClientTypeId>(id: K) => Promise<ClientRegistry[K]>;
   config?: Record<string, unknown>;
   connectorUsageCollector?: unknown;
   log: Logger;
   secrets?: Record<string, unknown>;
-  /**
-   * Resolves a client for the given client type id, building and leasing it
-   * on first use and reusing it for the lifetime of the lease.
-   */
-  getClient: <K extends ClientTypeId>(id: K) => Promise<ClientRegistry[K]>;
 }
 
 // ============================================================================

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/client_type_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/client_type_spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { AxiosInstance } from 'axios';
+import type { Logger } from '@kbn/logging';
+
+export interface ConnectorNetwork {
+  ensureUriAllowed(url: string): void;
+  ensureHostnameAllowed(host: string): void;
+}
+
+export interface CredentialAccessor {
+  getAuthHeaders(): Promise<Record<string, string>>;
+}
+
+export interface BuildContext {
+  logger: Logger;
+  axiosInstance: AxiosInstance;
+  config?: Record<string, unknown>;
+  network: ConnectorNetwork;
+  credential: CredentialAccessor;
+}
+
+export interface ClientTypeSpec<TClient> {
+  id: string;
+  build(ctx: BuildContext): Promise<TClient>;
+  terminate(client: TClient): Promise<void>;
+  isUserError?(err: unknown): boolean;
+}

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/client_type_spec.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/client_type_spec.ts
@@ -30,6 +30,13 @@ export interface BuildContext {
 export interface ClientTypeSpec<TClient> {
   id: string;
   build(ctx: BuildContext): Promise<TClient>;
+  /** Called when evicting a pooled instance (connector delete, TTL, etc.); not wired in PoC. */
   terminate(client: TClient): Promise<void>;
+  /**
+   * Optional: return true to classify a connect failure as a USER error (bad config, auth).
+   * Boolean rather than TaskErrorSource because this package cannot import TaskErrorSource
+   * (shared-common cannot depend on a plugin).
+   * Only ever promotes to USER; FRAMEWORK is the default for unclassified failures.
+   */
   isUserError?(err: unknown): boolean;
 }

--- a/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/index.ts
+++ b/src/platform/packages/shared/kbn-connector-specs/src/lib/clients/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ClientTypeSpec } from './client_type_spec';
+
+export type {
+  ClientTypeSpec,
+  BuildContext,
+  ConnectorNetwork,
+  CredentialAccessor,
+} from './client_type_spec';
+
+// No client types are registered yet. `ClientTypeId` resolves to `never`
+// until a client type is added to `ClientRegistry`.
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface ClientRegistry {}
+
+export type ClientTypeId = keyof ClientRegistry;
+
+export const clientTypes: Readonly<Record<ClientTypeId, ClientTypeSpec<unknown>>> = {};

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.test.ts
@@ -1962,6 +1962,35 @@ describe('delete()', () => {
         `Failed to delete auth tokens for connector "1" after delete: Fail`
       );
     });
+
+    test('calls evictClientPool with the connector id when provided', async () => {
+      const evictClientPool = jest.fn();
+      const client = new ActionsClient({
+        logger,
+        actionTypeRegistry,
+        authTypeRegistry,
+        unsecuredSavedObjectsClient,
+        scopedClusterClient,
+        kibanaIndices,
+        inMemoryConnectors: [],
+        actionExecutor,
+        bulkExecutionEnqueuer,
+        request,
+        authorization: authorization as unknown as ActionsAuthorization,
+        auditLogger,
+        usageCounter: mockUsageCounter,
+        connectorTokenClient,
+        getEventLogClient,
+        encryptedSavedObjectsClient,
+        isESOCanEncrypt,
+        getAxiosInstanceWithAuth,
+        evictClientPool,
+      });
+
+      await client.delete({ id: '1' });
+
+      expect(evictClientPool).toHaveBeenCalledWith('1');
+    });
   });
 
   describe('auditLogger', () => {

--- a/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
+++ b/x-pack/platform/plugins/shared/actions/server/actions_client/actions_client.ts
@@ -125,6 +125,7 @@ export interface ConstructorOptions {
   isESOCanEncrypt: boolean;
   connectorLifecycleListeners?: ConnectorLifecycleListener[];
   getCurrentUserProfileId?: (request: KibanaRequest) => Promise<string | undefined>;
+  evictClientPool?: (connectorId: string) => void;
 }
 
 export interface ActionsClientContext {
@@ -152,6 +153,7 @@ export interface ActionsClientContext {
   isESOCanEncrypt: boolean;
   connectorLifecycleListeners?: ConnectorLifecycleListener[];
   getCurrentUserProfileId?: (request: KibanaRequest) => Promise<string | undefined>;
+  evictClientPool?: (connectorId: string) => void;
 }
 
 const noop = async (_request: KibanaRequest): Promise<string | undefined> => undefined;
@@ -182,6 +184,7 @@ export class ActionsClient {
     isESOCanEncrypt,
     connectorLifecycleListeners,
     getCurrentUserProfileId,
+    evictClientPool,
   }: ConstructorOptions) {
     this.context = {
       logger,
@@ -206,6 +209,7 @@ export class ActionsClient {
       isESOCanEncrypt,
       connectorLifecycleListeners,
       getCurrentUserProfileId: getCurrentUserProfileId ?? noop,
+      evictClientPool,
     };
   }
 
@@ -621,6 +625,8 @@ export class ActionsClient {
       },
       this.context.logger
     );
+
+    this.context.evictClientPool?.(id);
 
     try {
       await this.context.connectorTokenClient.deleteConnectorTokens({

--- a/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.ts
+++ b/x-pack/platform/plugins/shared/actions/server/application/connector/methods/update/update.ts
@@ -209,6 +209,8 @@ export async function update({ context, id, action }: ConnectorUpdateParams): Pr
     throw result;
   }
 
+  context.evictClientPool?.(id);
+
   try {
     await context.connectorTokenClient.deleteConnectorTokens({ connectorId: id, authMode });
   } catch (e) {

--- a/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/get_axios_instance.ts
@@ -13,7 +13,7 @@ import type {
 } from 'axios';
 import axios from 'axios';
 import type { Logger } from '@kbn/core/server';
-import type { AuthMode, GetTokenOpts } from '@kbn/connector-specs';
+import type { AuthMode, AuthContext, CredentialAccessor, GetTokenOpts } from '@kbn/connector-specs';
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { ActionInfo } from './action_executor';
 import type { AuthTypeRegistry } from '../auth_types';
@@ -123,6 +123,71 @@ export interface GetAxiosInstanceWithAuthFnOpts {
 export type GetAxiosInstanceWithAuthFn = (
   opts: GetAxiosInstanceWithAuthFnOpts
 ) => Promise<AxiosInstance>;
+
+export class UnsupportedAuthProducerError extends Error {
+  constructor(authTypeId: string) {
+    super(
+      `[Action][ExternalService] Auth type "${authTypeId}" does not support getAuthHeaders for native HTTP clients.`
+    );
+    this.name = 'UnsupportedAuthProducerError';
+  }
+}
+
+export interface GetCredentialFnOpts {
+  connectorId: string;
+  connectorTokenClient?: ConnectorTokenClientContract;
+  secrets: ValidatedSecrets;
+  authMode?: AuthMode;
+  profileUid?: string;
+}
+
+export type GetCredentialFn = (opts: GetCredentialFnOpts) => CredentialAccessor;
+
+export const getCredentialWithAuth = ({
+  authTypeRegistry,
+  configurationUtilities,
+  logger,
+}: GetAxiosInstanceOpts): GetCredentialFn => {
+  return ({
+    connectorId,
+    secrets,
+    connectorTokenClient,
+    authMode,
+    profileUid,
+  }: GetCredentialFnOpts): CredentialAccessor => {
+    const authTypeId = (secrets as { authType?: string }).authType || 'none';
+    const authType = authTypeRegistry.get(authTypeId);
+
+    const strategy = getAxiosAuthStrategy(authTypeId);
+    const strategyDeps = {
+      connectorId,
+      secrets,
+      connectorTokenClient,
+      logger,
+      configurationUtilities,
+      authMode,
+      profileUid,
+    };
+
+    const authCtx: AuthContext = {
+      getCustomHostSettings: (url: string) => configurationUtilities.getCustomHostSettings(url),
+      getToken: (opts: GetTokenOpts) => strategy.getToken(opts, strategyDeps),
+      logger,
+      proxySettings: configurationUtilities.getProxySettings(),
+      sslSettings: configurationUtilities.getSSLSettings(),
+    };
+
+    return {
+      getAuthHeaders: async () => {
+        if (!authType.getAuthHeaders) {
+          throw new UnsupportedAuthProducerError(authTypeId);
+        }
+        return authType.getAuthHeaders(authCtx, secrets);
+      },
+    };
+  };
+};
+
 export const getAxiosInstanceWithAuth = ({
   authTypeRegistry,
   cloud,

--- a/x-pack/platform/plugins/shared/actions/server/lib/index.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/index.ts
@@ -47,3 +47,4 @@ export { createConnectorTypeFromSpec } from './single_file_connectors/create_con
 export { getDeleteTokenAxiosInterceptor } from './delete_token_axios_interceptor';
 export { OAuthAuthorizationService } from './oauth_authorization_service';
 export type { OAuthConfig } from './oauth_authorization_service';
+export { LeasePool } from './lease_pool';

--- a/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.test.ts
@@ -1,0 +1,387 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LeasePool, IDLE_TIMEOUT_MS } from './lease_pool';
+
+const noopTerminate = jest.fn().mockResolvedValue(undefined);
+
+const makeFakePerf = () => {
+  let perfNow = 1;
+  jest.spyOn(performance, 'now').mockImplementation(() => perfNow);
+
+  return {
+    tick: (ms: number) => {
+      perfNow += ms;
+    },
+    restore: () => {
+      jest.restoreAllMocks();
+    },
+  };
+};
+
+describe('LeasePool', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('reuse: N sequential leases on the same key', () => {
+    it('calls buildFn exactly once and returns the same client each time', async () => {
+      const pool = new LeasePool<string>();
+      let callCount = 0;
+      const buildFn = async () => {
+        callCount++;
+        return 'client-a';
+      };
+
+      const r1 = await pool.lease('key', buildFn, noopTerminate);
+      const r2 = await pool.lease('key', buildFn, noopTerminate);
+      const r3 = await pool.lease('key', buildFn, noopTerminate);
+
+      expect(callCount).toBe(1);
+      expect(r1).toBe('client-a');
+      expect(r2).toBe('client-a');
+      expect(r3).toBe('client-a');
+    });
+  });
+
+  describe('anti-stampede: M concurrent cold callers on the same key', () => {
+    it('calls buildFn exactly once even when all callers arrive before the build resolves', async () => {
+      const pool = new LeasePool<string>();
+      let callCount = 0;
+      let resolve!: (v: string) => void;
+      const buildPromise = new Promise<string>((res) => {
+        resolve = res;
+      });
+      const buildFn = async () => {
+        callCount++;
+        return buildPromise;
+      };
+
+      const leases = [
+        pool.lease('key', buildFn, noopTerminate),
+        pool.lease('key', buildFn, noopTerminate),
+        pool.lease('key', buildFn, noopTerminate),
+      ];
+
+      resolve('client-b');
+      const results = await Promise.all(leases);
+
+      expect(callCount).toBe(1);
+      expect(results).toEqual(['client-b', 'client-b', 'client-b']);
+    });
+  });
+
+  describe('evict-on-reject', () => {
+    it('removes the key when the build rejects so the next lease rebuilds', async () => {
+      const pool = new LeasePool<string>();
+      let callCount = 0;
+      const buildFn = jest.fn().mockImplementationOnce(async () => {
+        callCount++;
+        throw new Error('build failed');
+      });
+      buildFn.mockImplementationOnce(async () => {
+        callCount++;
+        return 'client-c';
+      });
+
+      await expect(pool.lease('key', buildFn, noopTerminate)).rejects.toThrow('build failed');
+
+      const result = await pool.lease('key', buildFn, noopTerminate);
+      expect(result).toBe('client-c');
+      expect(callCount).toBe(2);
+    });
+
+    it('propagates the rejection to callers waiting on the same in-flight build', async () => {
+      const pool = new LeasePool<string>();
+      let reject!: (e: Error) => void;
+      const buildPromise = new Promise<string>((_, rej) => {
+        reject = rej;
+      });
+      const buildFn = async () => buildPromise;
+
+      const p1 = pool.lease('key', buildFn, noopTerminate);
+      const p2 = pool.lease('key', buildFn, noopTerminate);
+
+      reject(new Error('concurrent fail'));
+
+      await expect(p1).rejects.toThrow('concurrent fail');
+      await expect(p2).rejects.toThrow('concurrent fail');
+    });
+  });
+
+  describe('isolation: distinct keys', () => {
+    it('calls buildFn independently for different keys', async () => {
+      const pool = new LeasePool<string>();
+      let aCount = 0;
+      let bCount = 0;
+
+      const clientA = await pool.lease(
+        'key-a',
+        async () => {
+          aCount++;
+          return 'client-a';
+        },
+        noopTerminate
+      );
+      const clientB = await pool.lease(
+        'key-b',
+        async () => {
+          bCount++;
+          return 'client-b';
+        },
+        noopTerminate
+      );
+
+      expect(aCount).toBe(1);
+      expect(bCount).toBe(1);
+      expect(clientA).toBe('client-a');
+      expect(clientB).toBe('client-b');
+    });
+  });
+
+  describe('updateAgeOnGet: re-lease before expiry survives', () => {
+    let perf: ReturnType<typeof makeFakePerf>;
+
+    beforeEach(() => {
+      perf = makeFakePerf();
+    });
+
+    afterEach(() => {
+      perf.restore();
+    });
+
+    it('does not expire an entry re-leased just before the idle TTL', async () => {
+      const pool = new LeasePool<string>();
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+
+      await pool.lease('conn:mcp:shared', async () => 'client', terminateSpy);
+
+      perf.tick(IDLE_TIMEOUT_MS - 1000);
+      await pool.lease('conn:mcp:shared', async () => 'client', terminateSpy);
+
+      perf.tick(IDLE_TIMEOUT_MS);
+      await Promise.resolve();
+
+      expect(terminateSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('evict(connectorId)', () => {
+    it('calls terminate on matching-prefix resolved entries and removes them', async () => {
+      const pool = new LeasePool<string>();
+      const terminateA = jest.fn().mockResolvedValue(undefined);
+      const terminateB = jest.fn().mockResolvedValue(undefined);
+
+      await pool.lease('conn-a:mcp:shared', async () => 'client-a', terminateA);
+      await pool.lease('conn-b:mcp:shared', async () => 'client-b', terminateB);
+
+      pool.evict('conn-a');
+
+      await Promise.resolve();
+
+      expect(terminateA).toHaveBeenCalledWith('client-a');
+      expect(terminateB).not.toHaveBeenCalled();
+    });
+
+    it('removes the entry whether terminate resolves or rejects (best-effort)', async () => {
+      const pool = new LeasePool<string>();
+      const terminateFailing = jest.fn().mockRejectedValue(new Error('terminate failed'));
+
+      await pool.lease('conn-x:mcp:shared', async () => 'client-x', terminateFailing);
+
+      pool.evict('conn-x');
+      await Promise.resolve();
+
+      let buildCount = 0;
+      await pool.lease(
+        'conn-x:mcp:shared',
+        async () => {
+          buildCount++;
+          return 'client-x2';
+        },
+        noopTerminate
+      );
+
+      expect(buildCount).toBe(1);
+    });
+
+    it('terminates after resolve when evicting an in-progress entry', async () => {
+      const pool = new LeasePool<string>();
+      let resolveClient!: (v: string) => void;
+      const inFlight = new Promise<string>((res) => {
+        resolveClient = res;
+      });
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+
+      const leasePromise = pool.lease('conn-y:mcp:shared', async () => inFlight, terminateSpy);
+
+      pool.evict('conn-y');
+      await Promise.resolve();
+
+      expect(terminateSpy).not.toHaveBeenCalled();
+
+      resolveClient('client-y');
+      await leasePromise;
+      await Promise.resolve();
+
+      expect(terminateSpy).toHaveBeenCalledTimes(1);
+      expect(terminateSpy).toHaveBeenCalledWith('client-y');
+    });
+
+    it('does not terminate when evicting an entry whose build rejects', async () => {
+      const pool = new LeasePool<string>();
+      let rejectClient!: (e: Error) => void;
+      const inFlight = new Promise<string>((_, rej) => {
+        rejectClient = rej;
+      });
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+
+      const leasePromise = pool.lease('conn-z:mcp:shared', async () => inFlight, terminateSpy);
+
+      pool.evict('conn-z');
+      await Promise.resolve();
+
+      rejectClient(new Error('build failed'));
+      await expect(leasePromise).rejects.toThrow('build failed');
+      await Promise.resolve();
+
+      expect(terminateSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not touch entries for a different connector', async () => {
+      const pool = new LeasePool<string>();
+      const terminateOther = jest.fn().mockResolvedValue(undefined);
+
+      await pool.lease('other-conn:mcp:shared', async () => 'other-client', terminateOther);
+
+      pool.evict('my-conn');
+      await Promise.resolve();
+
+      expect(terminateOther).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('idle expiry', () => {
+    let perf: ReturnType<typeof makeFakePerf>;
+
+    beforeEach(() => {
+      perf = makeFakePerf();
+    });
+
+    afterEach(() => {
+      perf.restore();
+    });
+
+    it('expires an idle entry after IDLE_TIMEOUT_MS', async () => {
+      const pool = new LeasePool<string>();
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+
+      await pool.lease('conn:mcp:shared', async () => 'client', terminateSpy);
+
+      perf.tick(IDLE_TIMEOUT_MS + 1);
+
+      let buildCount = 0;
+      const client2 = await pool.lease(
+        'conn:mcp:shared',
+        async () => {
+          buildCount++;
+          return 'client2';
+        },
+        noopTerminate
+      );
+      await Promise.resolve();
+
+      expect(terminateSpy).toHaveBeenCalledWith('client');
+      expect(buildCount).toBe(1);
+      expect(client2).toBe('client2');
+    });
+  });
+
+  describe('stop()', () => {
+    it('fire-and-forgets terminate on all resolved entries', async () => {
+      const pool = new LeasePool<string>();
+      const terminateA = jest.fn().mockResolvedValue(undefined);
+      const terminateB = jest.fn().mockResolvedValue(undefined);
+
+      await pool.lease('conn-a:mcp:shared', async () => 'client-a', terminateA);
+      await pool.lease('conn-b:mcp:shared', async () => 'client-b', terminateB);
+
+      pool.stop();
+
+      await Promise.resolve();
+
+      expect(terminateA).toHaveBeenCalledWith('client-a');
+      expect(terminateB).toHaveBeenCalledWith('client-b');
+    });
+
+    it('returns synchronously (does not await terminate)', () => {
+      const pool = new LeasePool<string>();
+
+      expect(() => pool.stop()).not.toThrow();
+    });
+
+    it('terminates after resolve when stopping with an in-progress entry', async () => {
+      const pool = new LeasePool<string>();
+      let resolveClient!: (v: string) => void;
+      const inFlight = new Promise<string>((res) => {
+        resolveClient = res;
+      });
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+
+      const leasePromise = pool.lease('conn:mcp:shared', async () => inFlight, terminateSpy);
+
+      pool.stop();
+
+      expect(terminateSpy).not.toHaveBeenCalled();
+
+      resolveClient('client');
+      await leasePromise;
+      await Promise.resolve();
+
+      expect(terminateSpy).toHaveBeenCalledTimes(1);
+      expect(terminateSpy).toHaveBeenCalledWith('client');
+    });
+
+    it('does not terminate when stopping with an entry whose build rejects', async () => {
+      const pool = new LeasePool<string>();
+      let rejectClient!: (e: Error) => void;
+      const inFlight = new Promise<string>((_, rej) => {
+        rejectClient = rej;
+      });
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+
+      const leasePromise = pool.lease('conn:mcp:shared', async () => inFlight, terminateSpy);
+
+      pool.stop();
+
+      rejectClient(new Error('build failed'));
+      await expect(leasePromise).rejects.toThrow('build failed');
+      await Promise.resolve();
+
+      expect(terminateSpy).not.toHaveBeenCalled();
+    });
+
+    it('empties the cache', async () => {
+      const pool = new LeasePool<string>();
+
+      await pool.lease('conn:mcp:shared', async () => 'client', noopTerminate);
+
+      pool.stop();
+
+      let buildCount = 0;
+      await pool.lease(
+        'conn:mcp:shared',
+        async () => {
+          buildCount++;
+          return 'client2';
+        },
+        noopTerminate
+      );
+      expect(buildCount).toBe(1);
+    });
+  });
+});

--- a/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/lease_pool.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { LRUCache } from 'lru-cache';
+import type { Logger } from '@kbn/core/server';
+
+export const IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+const MAX_ENTRIES = 1000;
+
+interface PoolEntry<TClient> {
+  promise: Promise<TClient>;
+  terminate: (client: TClient) => Promise<void>;
+}
+
+export class LeasePool<TClient> {
+  private readonly cache: LRUCache<string, PoolEntry<TClient>>;
+  private readonly logger?: Logger;
+
+  constructor(logger?: Logger) {
+    this.logger = logger;
+    this.cache = new LRUCache<string, PoolEntry<TClient>>({
+      ttl: IDLE_TIMEOUT_MS,
+      ttlAutopurge: true,
+      ttlResolution: 0,
+      updateAgeOnGet: true,
+      max: MAX_ENTRIES,
+      dispose: (value, key) => {
+        void value.promise.then(
+          (client) =>
+            value.terminate(client).catch((err) => {
+              this.logger?.warn(`Failed to terminate client for key "${key}": ${err.message}`);
+            }),
+          () => {}
+        );
+      },
+    });
+  }
+
+  lease(
+    key: string,
+    buildFn: () => Promise<TClient>,
+    terminate: (client: TClient) => Promise<void>
+  ): Promise<TClient> {
+    const existing = this.cache.get(key);
+    if (existing !== undefined) {
+      return existing.promise;
+    }
+
+    const promise = Promise.resolve().then(buildFn);
+    promise.catch(() => {
+      this.cache.delete(key);
+    });
+
+    const entry: PoolEntry<TClient> = { promise, terminate };
+    this.cache.set(key, entry);
+    return promise;
+  }
+
+  evict(connectorId: string): void {
+    const prefix = `${connectorId}:`;
+    const keysToEvict = [...this.cache.keys()].filter((key) => key.startsWith(prefix));
+    for (const key of keysToEvict) {
+      this.cache.delete(key);
+    }
+  }
+
+  stop(): void {
+    this.cache.clear();
+  }
+}

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.test.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { buildClientLeaseKey } from './build_client_lease_key';
+
+describe('buildClientLeaseKey', () => {
+  it('formats key as connectorId:clientTypeId:shared', () => {
+    expect(buildClientLeaseKey('connector-abc', 'mcp')).toBe('connector-abc:mcp:shared');
+  });
+
+  it('preserves special characters in connectorId', () => {
+    expect(buildClientLeaseKey('.github', 'mcp')).toBe('.github:mcp:shared');
+  });
+});

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/build_client_lease_key.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+/**
+ * Pool key = one shared client instance per (connector instance, client type).
+ *
+ * - connectorId: execOptions.actionId (two saved connectors must not share a session).
+ * - clientTypeId: registry slot ('mcp').
+ * - ':shared': one pool entry per connector+type (not per sub-action). Per-user OAuth pool
+ *   key isolation via profileUid is the deferred next term.
+ */
+export function buildClientLeaseKey(connectorId: string, clientTypeId: string): string {
+  return `${connectorId}:${clientTypeId}:shared`;
+}

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_from_spec.ts
@@ -20,12 +20,14 @@ import { generateParamsSchema } from './generate_params_schema';
 import { generateSecretsSchema } from './generate_secrets_schema';
 import { generateExecutorFunction } from './generate_executor_function';
 import { generateConfigSchema } from './generate_config_schema';
+import { createConnectorNetwork } from './create_connector_network';
 
 export const createConnectorTypeFromSpec = (
   spec: ConnectorSpec,
   actions: ActionsPluginSetupContract
 ): ActionType<ActionTypeConfig, ActionTypeSecrets, ActionTypeParams, unknown> => {
   const configUtils = actions.getActionsConfigurationUtilities();
+  const network = createConnectorNetwork(configUtils);
 
   const hasActions = Boolean(spec.actions);
 
@@ -33,6 +35,9 @@ export const createConnectorTypeFromSpec = (
     ? generateExecutorFunction({
         actions: spec.actions,
         getAxiosInstanceWithAuth: actions.getAxiosInstanceWithAuth,
+        getCredential: actions.getCredential,
+        getClientLeasePool: actions.getClientLeasePool,
+        network,
       })
     : undefined;
 

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_network.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_network.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { createConnectorNetwork, AllowlistDeniedError } from './create_connector_network';
+import type { ActionsConfigurationUtilities } from '../../actions_config';
+
+describe('createConnectorNetwork', () => {
+  const mockConfigUtils = {
+    ensureUriAllowed: jest.fn(),
+    ensureHostnameAllowed: jest.fn(),
+  } as unknown as ActionsConfigurationUtilities;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an object with exactly ensureUriAllowed and ensureHostnameAllowed', () => {
+    const network = createConnectorNetwork(mockConfigUtils);
+    expect(Object.keys(network).sort()).toEqual(['ensureHostnameAllowed', 'ensureUriAllowed']);
+  });
+
+  it('delegates ensureUriAllowed to configUtils', () => {
+    const network = createConnectorNetwork(mockConfigUtils);
+    network.ensureUriAllowed('https://allowed.example.com');
+    expect(mockConfigUtils.ensureUriAllowed).toHaveBeenCalledWith('https://allowed.example.com');
+  });
+
+  it('delegates ensureHostnameAllowed to configUtils', () => {
+    const network = createConnectorNetwork(mockConfigUtils);
+    network.ensureHostnameAllowed('allowed.example.com');
+    expect(mockConfigUtils.ensureHostnameAllowed).toHaveBeenCalledWith('allowed.example.com');
+  });
+
+  it('wraps an ensureUriAllowed denial in AllowlistDeniedError, preserving message and cause', () => {
+    const original = new Error('URI not allowed');
+    (mockConfigUtils.ensureUriAllowed as jest.Mock).mockImplementation(() => {
+      throw original;
+    });
+    const network = createConnectorNetwork(mockConfigUtils);
+
+    const thrown = (() => {
+      try {
+        network.ensureUriAllowed('https://denied.example.com');
+      } catch (e) {
+        return e;
+      }
+    })();
+
+    expect(thrown).toBeInstanceOf(AllowlistDeniedError);
+    expect((thrown as Error).message).toBe('URI not allowed');
+    expect((thrown as Error).cause).toBe(original);
+  });
+
+  it('wraps an ensureHostnameAllowed denial in AllowlistDeniedError', () => {
+    (mockConfigUtils.ensureHostnameAllowed as jest.Mock).mockImplementation(() => {
+      throw new Error('hostname not allowed');
+    });
+    const network = createConnectorNetwork(mockConfigUtils);
+
+    expect(() => network.ensureHostnameAllowed('denied.example.com')).toThrow(AllowlistDeniedError);
+    expect(() => network.ensureHostnameAllowed('denied.example.com')).toThrow(
+      'hostname not allowed'
+    );
+  });
+});

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_network.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/create_connector_network.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { ConnectorNetwork } from '@kbn/connector-specs';
+import type { ActionsConfigurationUtilities } from '../../actions_config';
+
+/**
+ * Thrown when an egress destination is not on `xpack.actions.allowedHosts`.
+ *
+ * Typed so the executor can classify it as a USER error (permanent bad config:
+ * it cannot succeed on retry until an admin widens the allowlist) instead of a
+ * retryable FRAMEWORK fault, without string-matching the underlying message.
+ */
+export class AllowlistDeniedError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options?.cause !== undefined ? { cause: options.cause } : undefined);
+    this.name = 'AllowlistDeniedError';
+  }
+}
+
+const toAllowlistDeniedError = (err: unknown): never => {
+  throw new AllowlistDeniedError(err instanceof Error ? err.message : String(err), { cause: err });
+};
+
+export const createConnectorNetwork = (
+  configUtils: ActionsConfigurationUtilities
+): ConnectorNetwork => ({
+  ensureUriAllowed: (url) => {
+    try {
+      configUtils.ensureUriAllowed(url);
+    } catch (err) {
+      toAllowlistDeniedError(err);
+    }
+  },
+  ensureHostnameAllowed: (host) => {
+    try {
+      configUtils.ensureHostnameAllowed(host);
+    } catch (err) {
+      toAllowlistDeniedError(err);
+    }
+  },
+});

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.test.ts
@@ -9,16 +9,30 @@ import { loggingSystemMock } from '@kbn/core/server/mocks';
 import type { MockedLogger } from '@kbn/logging-mocks';
 import { generateExecutorFunction } from './generate_executor_function';
 import { setConnectorActionErrorMeta } from '@kbn/connector-specs';
-import type { ConnectorSpec } from '@kbn/connector-specs';
-import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
+import type {
+  ActionContext,
+  BuildContext,
+  ConnectorNetwork,
+  ConnectorSpec,
+} from '@kbn/connector-specs';
+import type { GetAxiosInstanceWithAuthFn, GetCredentialFn } from '../get_axios_instance';
+import { LeasePool } from '../lease_pool';
+import { createConnectorNetwork } from './create_connector_network';
+import type { ActionsConfigurationUtilities } from '../../actions_config';
+import { TaskErrorSource } from '@kbn/task-manager-plugin/server';
+import { getErrorSource } from '@kbn/task-manager-plugin/server/task_running';
 
 describe('generateExecutorFunction', () => {
   const connectorId = 'test-connector-id';
 
   let logger: MockedLogger;
   let mockGetAxiosInstanceWithAuth: jest.MockedFunction<GetAxiosInstanceWithAuthFn>;
+  let mockGetCredential: jest.MockedFunction<GetCredentialFn>;
+  let mockCredential: { getAuthHeaders: jest.Mock };
   let mockAxiosInstance: object;
   let mockHandler: jest.Mock;
+  let fakeLeasePool: LeasePool<unknown>;
+  let mockNetwork: ConnectorNetwork;
 
   const makeExecOptions = (params: Record<string, unknown>) =>
     ({
@@ -43,7 +57,13 @@ describe('generateExecutorFunction', () => {
     logger = loggingSystemMock.createLogger();
     mockAxiosInstance = { get: jest.fn() };
     mockGetAxiosInstanceWithAuth = jest.fn().mockResolvedValue(mockAxiosInstance);
+    mockCredential = {
+      getAuthHeaders: jest.fn().mockResolvedValue({ Authorization: 'Bearer secret' }),
+    };
+    mockGetCredential = jest.fn().mockReturnValue(mockCredential);
     mockHandler = jest.fn().mockResolvedValue({ result: 'ok' });
+    fakeLeasePool = new LeasePool<unknown>();
+    mockNetwork = { ensureUriAllowed: jest.fn(), ensureHostnameAllowed: jest.fn() };
   });
 
   const makeActions = (handler: jest.Mock = mockHandler): ConnectorSpec['actions'] => ({
@@ -54,12 +74,18 @@ describe('generateExecutorFunction', () => {
     },
   });
 
+  const makeExecutor = (handler: jest.Mock = mockHandler) =>
+    generateExecutorFunction({
+      actions: makeActions(handler),
+      getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+      getCredential: mockGetCredential,
+      getClientLeasePool: () => fakeLeasePool,
+      network: mockNetwork,
+    });
+
   describe('successful execution', () => {
     it('returns status ok with handler result as data', async () => {
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const result = await executor(
         makeExecOptions({ subAction: 'testAction', subActionParams: { foo: 'bar' } })
@@ -69,10 +95,7 @@ describe('generateExecutorFunction', () => {
     });
 
     it('passes subActionParams to the handler', async () => {
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const subActionParams = { message: 'hello', count: 3 };
       await executor(makeExecOptions({ subAction: 'testAction', subActionParams }));
@@ -80,20 +103,23 @@ describe('generateExecutorFunction', () => {
       expect(mockHandler).toHaveBeenCalledWith(expect.anything(), subActionParams);
     });
 
-    it('passes config, secrets, and axios instance in the handler context', async () => {
+    it('passes config, secrets, axios instance, and getClient in the handler context', async () => {
       const config = { url: 'https://example.com' };
       const secrets = { token: 'secret' };
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const opts = makeExecOptions({ subAction: 'testAction', subActionParams: {} });
       await executor({ ...opts, config, secrets });
 
       expect(mockHandler).toHaveBeenCalledWith(
-        { log: logger, client: mockAxiosInstance, config, secrets },
+        expect.objectContaining({
+          log: logger,
+          client: mockAxiosInstance,
+          config,
+          secrets,
+          getClient: expect.any(Function),
+        }),
         {}
       );
     });
@@ -101,10 +127,7 @@ describe('generateExecutorFunction', () => {
     it('returns empty object as data when handler returns null', async () => {
       mockHandler.mockResolvedValue(null);
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const result = await executor(
         makeExecOptions({ subAction: 'testAction', subActionParams: {} })
@@ -116,10 +139,7 @@ describe('generateExecutorFunction', () => {
     it('returns empty object as data when handler returns undefined', async () => {
       mockHandler.mockResolvedValue(undefined);
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const result = await executor(
         makeExecOptions({ subAction: 'testAction', subActionParams: {} })
@@ -135,10 +155,7 @@ describe('generateExecutorFunction', () => {
       const authMode = 'basic' as never;
       const profileUid = 'profile-123';
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       await executor({
         ...makeExecOptions({ subAction: 'testAction', subActionParams: {} }),
@@ -161,10 +178,7 @@ describe('generateExecutorFunction', () => {
     });
 
     it('passes fetchOptions max_content_length to getAxiosInstanceWithAuth', async () => {
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       await executor(
         makeExecOptions({
@@ -182,12 +196,473 @@ describe('generateExecutorFunction', () => {
     });
   });
 
-  describe('unrecognized subAction', () => {
-    it('throws and logs an error for an unknown subAction', async () => {
+  describe('ctx.getClient - build receives network from generateExecutorFunction', () => {
+    it('passes network to clientType.build', async () => {
+      const fakeClient = { id: 'x' };
+      const buildSpy = jest.fn().mockResolvedValue(fakeClient);
+      const fakeClientType = {
+        id: 'typed',
+        build: buildSpy,
+        terminate: jest.fn(),
+      };
+
+      const executor = generateExecutorFunction({
+        actions: {
+          testAction: {
+            isTool: true,
+            input: {} as never,
+            handler: jest.fn(async (ctx: ActionContext) => {
+              await (ctx.getClient as unknown as (id: string) => Promise<unknown>)('typed');
+              return {};
+            }),
+          },
+        },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        network: mockNetwork,
+        clientTypes: { typed: fakeClientType },
+      });
+
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      expect(buildSpy).toHaveBeenCalledWith(expect.objectContaining({ network: mockNetwork }));
+    });
+
+    it('passes credential to clientType.build from getCredential', async () => {
+      const fakeClient = { id: 'x' };
+      const buildSpy = jest.fn().mockResolvedValue(fakeClient);
+      const fakeClientType = {
+        id: 'typed',
+        build: buildSpy,
+        terminate: jest.fn(),
+      };
+
+      const executor = generateExecutorFunction({
+        actions: {
+          testAction: {
+            isTool: true,
+            input: {} as never,
+            handler: jest.fn(async (ctx: ActionContext) => {
+              await (ctx.getClient as unknown as (id: string) => Promise<unknown>)('typed');
+              return {};
+            }),
+          },
+        },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        network: mockNetwork,
+        clientTypes: { typed: fakeClientType },
+      });
+
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      expect(mockGetCredential).toHaveBeenCalledWith({
+        connectorId,
+        secrets: { token: 'secret' },
+        connectorTokenClient: undefined,
+        authMode: undefined,
+        profileUid: undefined,
+      });
+      expect(buildSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credential: mockCredential,
+        })
+      );
+
+      const buildContext = buildSpy.mock.calls[0][0] as { credential: typeof mockCredential };
+      await buildContext.credential.getAuthHeaders();
+      expect(mockCredential.getAuthHeaders).toHaveBeenCalled();
+    });
+  });
+
+  describe('ctx.getClient — lease receives clientType.terminate as 3rd arg', () => {
+    it('passes clientType.terminate to pool.lease', async () => {
+      const terminateSpy = jest.fn().mockResolvedValue(undefined);
+      const fakeClient = { id: 'x' };
+      const fakeClientType = {
+        id: 'typed',
+        build: jest.fn().mockResolvedValue(fakeClient),
+        terminate: terminateSpy,
+      };
+
+      const leaseSpy = jest.spyOn(fakeLeasePool, 'lease');
+
+      const executor = generateExecutorFunction({
+        actions: {
+          testAction: {
+            isTool: true,
+            input: {} as never,
+            handler: jest.fn(async (ctx: ActionContext) => {
+              await (ctx.getClient as unknown as (id: string) => Promise<unknown>)('typed');
+              return {};
+            }),
+          },
+        },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        network: mockNetwork,
+        clientTypes: { typed: fakeClientType },
+      });
+
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      expect(leaseSpy).toHaveBeenCalledWith(expect.any(String), expect.any(Function), terminateSpy);
+    });
+  });
+
+  describe('ctx.getClient (pooled client access)', () => {
+    type GetClient = (id: string) => Promise<unknown>;
+
+    it('builds client once for N sequential requests (reuse)', async () => {
+      let buildCount = 0;
+      const fakeClient = { id: 'fake-client' };
+      const fakeClientType = {
+        id: 'fake',
+        build: jest.fn(async () => {
+          buildCount++;
+          return fakeClient;
+        }),
+        terminate: jest.fn(),
+      };
+
+      const capturedGetClients: GetClient[] = [];
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        capturedGetClients.push(ctx.getClient as unknown as GetClient);
+        return {};
+      });
+
+      const pool = new LeasePool<unknown>();
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { fake: fakeClientType },
+      });
+
+      // 3 sequential calls with same connectorId
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      // Request the client through each captured getClient
+      await Promise.all(capturedGetClients.map((getClient) => getClient('fake')));
+
+      expect(buildCount).toBe(1);
+    });
+
+    it('does not build when no client is requested (untouched → no build)', async () => {
+      let buildCount = 0;
+      const fakeClientType = {
+        id: 'unused',
+        build: jest.fn(async () => {
+          buildCount++;
+          return {};
+        }),
+        terminate: jest.fn(),
+      };
+
+      const pool = new LeasePool<unknown>();
       const executor = generateExecutorFunction({
         actions: makeActions(),
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { unused: fakeClientType },
       });
+
+      // Call executor but handler never calls ctx.getClient
+      await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
+
+      expect(buildCount).toBe(0);
+    });
+
+    it('surfaces a build rejection from getClient as a thrown FRAMEWORK-tagged error', async () => {
+      const fakeClientType = {
+        id: 'failing',
+        build: jest.fn(async () => {
+          throw new Error('build exploded');
+        }),
+        terminate: jest.fn(),
+      };
+
+      const pool = new LeasePool<unknown>();
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        await (ctx.getClient as unknown as GetClient)('failing'); // triggers build
+        return {};
+      });
+
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { failing: fakeClientType },
+      });
+
+      const thrown = await executor(
+        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
+      ).catch((e) => e);
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(getErrorSource(thrown)).toBe(TaskErrorSource.FRAMEWORK);
+    });
+
+    it('tags a build failure as USER when clientType.isUserError returns true', async () => {
+      const buildError = new Error('config.serverUrl is required');
+      const fakeClientType = {
+        id: 'typed',
+        build: jest.fn().mockRejectedValue(buildError),
+        terminate: jest.fn().mockResolvedValue(undefined),
+        isUserError: jest.fn().mockReturnValue(true),
+      };
+
+      const pool = new LeasePool<unknown>();
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        await (ctx.getClient as unknown as GetClient)('typed');
+        return {};
+      });
+
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { typed: fakeClientType },
+      });
+
+      const thrown = await executor(
+        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
+      ).catch((e) => e);
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(getErrorSource(thrown)).toBe(TaskErrorSource.USER);
+    });
+
+    it('MCP 401 connect failure surfaces with USER tag (end-to-end via isUserError seam)', async () => {
+      const mcpError = Object.assign(
+        new Error('Unauthorized error: Error POSTing to endpoint: Unauthorized'),
+        { httpStatus: 401 }
+      );
+      const fakeClientType = {
+        id: 'mcp',
+        build: jest.fn().mockRejectedValue(mcpError),
+        terminate: jest.fn().mockResolvedValue(undefined),
+        isUserError: (err: unknown) => {
+          const e = err as { httpStatus?: number };
+          return (
+            typeof e?.httpStatus === 'number' && (e.httpStatus === 401 || e.httpStatus === 403)
+          );
+        },
+      };
+
+      const pool = new LeasePool<unknown>();
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        await (ctx.getClient as unknown as GetClient)('mcp');
+        return {};
+      });
+
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { mcp: fakeClientType },
+      });
+
+      const thrown = await executor(
+        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
+      ).catch((e) => e);
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(getErrorSource(thrown)).toBe(TaskErrorSource.USER);
+    });
+
+    it('MCP 500 connect failure surfaces with FRAMEWORK tag', async () => {
+      const mcpError = Object.assign(new Error('Streamable HTTP error: Internal Server Error'), {
+        httpStatus: 500,
+      });
+      const fakeClientType = {
+        id: 'mcp',
+        build: jest.fn().mockRejectedValue(mcpError),
+        terminate: jest.fn().mockResolvedValue(undefined),
+        isUserError: (err: unknown) => {
+          const e = err as { httpStatus?: number };
+          return (
+            typeof e?.httpStatus === 'number' && (e.httpStatus === 401 || e.httpStatus === 403)
+          );
+        },
+      };
+
+      const pool = new LeasePool<unknown>();
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        await (ctx.getClient as unknown as GetClient)('mcp');
+        return {};
+      });
+
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { mcp: fakeClientType },
+      });
+
+      const thrown = await executor(
+        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
+      ).catch((e) => e);
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(getErrorSource(thrown)).toBe(TaskErrorSource.FRAMEWORK);
+    });
+
+    it('tags an allowlist (SSRF) denial as USER, not a retryable FRAMEWORK error', async () => {
+      // Real network seam over a config that denies every host, i.e. the connector's
+      // serverUrl is no longer on xpack.actions.allowedHosts (tightened after save).
+      const denyingConfigUtils = {
+        ensureUriAllowed: (uri: string) => {
+          throw new Error(
+            `target url "${uri}" is not added to the Kibana config xpack.actions.allowedHosts`
+          );
+        },
+        ensureHostnameAllowed: (host: string) => {
+          throw new Error(
+            `target hostname "${host}" is not added to the Kibana config xpack.actions.allowedHosts`
+          );
+        },
+      } as unknown as ActionsConfigurationUtilities;
+      const network = createConnectorNetwork(denyingConfigUtils);
+
+      const fakeClientType = {
+        id: 'mcp',
+        // build runs the allowlist check at connect time, like mcpClientType does.
+        build: jest.fn(async (ctx: BuildContext) => {
+          ctx.network.ensureUriAllowed('http://denied.example');
+          return {};
+        }),
+        terminate: jest.fn().mockResolvedValue(undefined),
+        // No client-level isUserError on purpose: an allowlist denial must be
+        // classified by the framework seam, not by each client string-matching a message.
+      };
+
+      const pool = new LeasePool<unknown>();
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        await (ctx.getClient as unknown as GetClient)('mcp');
+        return {};
+      });
+
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network,
+        clientTypes: { mcp: fakeClientType },
+      });
+
+      const thrown = await executor(
+        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
+      ).catch((e) => e);
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(getErrorSource(thrown)).toBe(TaskErrorSource.USER);
+    });
+
+    it('returns {status:error} for an untagged handler error — no getClient involved (regression)', async () => {
+      mockHandler.mockRejectedValue(new Error('direct handler failure'));
+
+      const result = await makeExecutor()(
+        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
+      );
+
+      expect(result).toEqual({
+        status: 'error',
+        message: 'direct handler failure',
+        actionId: connectorId,
+      });
+    });
+
+    it('surfaces a request for an unknown client type id as an error result', async () => {
+      const pool = new LeasePool<unknown>();
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        await (ctx.getClient as unknown as GetClient)('nope');
+        return {};
+      });
+
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: {},
+      });
+
+      const result = await executor(
+        makeExecOptions({ subAction: 'testAction', subActionParams: {} })
+      );
+
+      expect(result).toMatchObject({
+        status: 'error',
+        message: '[Action][ExternalService] Unknown client type nope.',
+      });
+    });
+
+    it('distinct connectorIds → distinct pool entries (isolation)', async () => {
+      let buildCount = 0;
+      const fakeClientType = {
+        id: 'fake',
+        build: jest.fn(async () => {
+          buildCount++;
+          return { buildNumber: buildCount };
+        }),
+        terminate: jest.fn(),
+      };
+
+      const pool = new LeasePool<unknown>();
+      const capturedGetClients: GetClient[] = [];
+      const handler = jest.fn(async (ctx: ActionContext) => {
+        capturedGetClients.push(ctx.getClient as unknown as GetClient);
+        return {};
+      });
+
+      const executor = generateExecutorFunction({
+        actions: { testAction: { isTool: true, input: {} as never, handler } },
+        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => pool,
+        network: mockNetwork,
+        clientTypes: { fake: fakeClientType },
+      });
+
+      const makeOptsFor = (id: string) =>
+        ({
+          ...makeExecOptions({ subAction: 'testAction', subActionParams: {} }),
+          actionId: id,
+        } as Parameters<typeof executor>[0]);
+
+      await executor(makeOptsFor('connector-1'));
+      await executor(makeOptsFor('connector-2'));
+
+      const [c1, c2] = await Promise.all(capturedGetClients.map((getClient) => getClient('fake')));
+
+      expect(buildCount).toBe(2);
+      expect(c1).not.toBe(c2);
+    });
+  });
+
+  describe('unrecognized subAction', () => {
+    it('throws and logs an error for an unknown subAction', async () => {
+      const executor = makeExecutor();
 
       await expect(
         executor(makeExecOptions({ subAction: 'unknownAction', subActionParams: {} }))
@@ -199,10 +674,7 @@ describe('generateExecutorFunction', () => {
     });
 
     it('does not call the handler when subAction is not registered', async () => {
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       await expect(
         executor(makeExecOptions({ subAction: 'notRegistered', subActionParams: {} }))
@@ -216,10 +688,7 @@ describe('generateExecutorFunction', () => {
     it('returns status error with the error message when handler throws an Error', async () => {
       mockHandler.mockRejectedValue(new Error('handler failed'));
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const result = await executor(
         makeExecOptions({ subAction: 'testAction', subActionParams: {} })
@@ -239,10 +708,7 @@ describe('generateExecutorFunction', () => {
       error.response = { headers: { 'content-length': '10485760' } };
       mockHandler.mockRejectedValue(error);
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const result = await executor(
         makeExecOptions({ subAction: 'testAction', subActionParams: {} })
@@ -273,6 +739,9 @@ describe('generateExecutorFunction', () => {
           },
         },
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        network: mockNetwork,
       });
 
       const result = await executor(
@@ -298,10 +767,7 @@ describe('generateExecutorFunction', () => {
       });
       mockHandler.mockRejectedValue(error);
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const result = await executor(
         makeExecOptions({ subAction: 'testAction', subActionParams: {} })
@@ -321,10 +787,7 @@ describe('generateExecutorFunction', () => {
     it('logs the error message when the handler throws', async () => {
       mockHandler.mockRejectedValue(new Error('handler failed'));
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       await executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }));
 
@@ -334,10 +797,7 @@ describe('generateExecutorFunction', () => {
     it('returns status error with stringified value when handler throws a non-Error', async () => {
       mockHandler.mockRejectedValue('string error');
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       const result = await executor(
         makeExecOptions({ subAction: 'testAction', subActionParams: {} })
@@ -353,10 +813,7 @@ describe('generateExecutorFunction', () => {
     it('does not throw when handler fails — returns error result instead', async () => {
       mockHandler.mockRejectedValue(new Error('boom'));
 
-      const executor = generateExecutorFunction({
-        actions: makeActions(),
-        getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
-      });
+      const executor = makeExecutor();
 
       await expect(
         executor(makeExecOptions({ subAction: 'testAction', subActionParams: {} }))
@@ -377,6 +834,9 @@ describe('generateExecutorFunction', () => {
       const executor = generateExecutorFunction({
         actions,
         getAxiosInstanceWithAuth: mockGetAxiosInstanceWithAuth,
+        getCredential: mockGetCredential,
+        getClientLeasePool: () => fakeLeasePool,
+        network: mockNetwork,
       });
 
       const result1 = await executor(

--- a/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
+++ b/x-pack/platform/plugins/shared/actions/server/lib/single_file_connectors/generate_executor_function.ts
@@ -10,13 +10,20 @@ import {
   getConnectorActionErrorMeta,
   getFinitePositiveNumber,
   getHeaderValue,
+  clientTypes as defaultClientTypes,
 } from '@kbn/connector-specs';
+import type { ActionContext, ClientTypeSpec, ConnectorNetwork } from '@kbn/connector-specs';
+import { createTaskRunError, TaskErrorSource } from '@kbn/task-manager-plugin/server';
+import { getErrorSource, isUserError } from '@kbn/task-manager-plugin/server/task_running';
 import type { ExecutorParams } from '../../sub_action_framework/types';
 import type {
   ActionTypeExecutorOptions as ConnectorTypeExecutorOptions,
   ActionTypeExecutorResult as ConnectorTypeExecutorResult,
 } from '../../types';
-import type { GetAxiosInstanceWithAuthFn } from '../get_axios_instance';
+import type { GetAxiosInstanceWithAuthFn, GetCredentialFn } from '../get_axios_instance';
+import type { LeasePool } from '../lease_pool';
+import { buildClientLeaseKey } from './build_client_lease_key';
+import { AllowlistDeniedError } from './create_connector_network';
 
 type RecordUnknown = Record<string, unknown>;
 interface FetchOptions {
@@ -65,9 +72,17 @@ const getErrorMeta = ({
 export const generateExecutorFunction = ({
   actions,
   getAxiosInstanceWithAuth,
+  getCredential,
+  getClientLeasePool,
+  network,
+  clientTypes = defaultClientTypes,
 }: {
   actions: ConnectorSpec['actions'];
   getAxiosInstanceWithAuth: GetAxiosInstanceWithAuthFn;
+  getCredential: GetCredentialFn;
+  getClientLeasePool: () => LeasePool<unknown>;
+  network: ConnectorNetwork;
+  clientTypes?: Readonly<Record<string, ClientTypeSpec<unknown>>>;
 }) =>
   async function (
     execOptions: ConnectorTypeExecutorOptions<RecordUnknown, RecordUnknown, RecordUnknown>
@@ -101,17 +116,50 @@ export const generateExecutorFunction = ({
         : {}),
     });
 
+    const credential = getCredential({
+      connectorId,
+      secrets,
+      connectorTokenClient,
+      authMode,
+      profileUid,
+    });
+
     if (!actions[subAction]) {
       const errorMessage = `[Action][ExternalService] Unsupported subAction type ${subAction}.`;
       logger.error(errorMessage);
       throw new Error(errorMessage);
     }
 
+    const pool = getClientLeasePool();
+    const getClient = async (id: string): Promise<unknown> => {
+      const clientType = clientTypes[id];
+      if (!clientType) {
+        throw new Error(`[Action][ExternalService] Unknown client type ${id}.`);
+      }
+      try {
+        return await pool.lease(
+          buildClientLeaseKey(connectorId, id),
+          () => clientType.build({ logger, axiosInstance, config, network, credential }),
+          clientType.terminate
+        );
+      } catch (err) {
+        // An allowlist (SSRF) denial is permanent bad config, not a retryable fault:
+        // classify it at the framework seam so every client type benefits, rather than
+        // relying on each client to string-match the message.
+        const isUser =
+          err instanceof AllowlistDeniedError ||
+          isUserError(err) ||
+          (clientType.isUserError?.(err) ?? false);
+        throw createTaskRunError(err, isUser ? TaskErrorSource.USER : TaskErrorSource.FRAMEWORK);
+      }
+    };
+
     const actionContext = {
       log: logger,
       client: axiosInstance,
       secrets,
       config,
+      getClient: getClient as ActionContext['getClient'],
     };
 
     try {
@@ -124,6 +172,7 @@ export const generateExecutorFunction = ({
 
       return { status: 'ok', data, actionId: connectorId };
     } catch (error) {
+      if (error instanceof Error && getErrorSource(error)) throw error;
       const errorMessage = error instanceof Error ? error.message : String(error);
       const contentLengthBytes = getResponseSizeHeaderBytes({
         error,

--- a/x-pack/platform/plugins/shared/actions/server/mocks.ts
+++ b/x-pack/platform/plugins/shared/actions/server/mocks.ts
@@ -33,6 +33,8 @@ const createSetupMock = () => {
     registerType: jest.fn(),
     registerSubActionConnectorType: jest.fn(),
     getAxiosInstanceWithAuth: jest.fn(),
+    getCredential: jest.fn(),
+    getClientLeasePool: jest.fn(),
     isPreconfiguredConnector: jest.fn(),
     getSubActionConnectorClass: jest.fn(),
     getCaseConnectorClass: jest.fn(),

--- a/x-pack/platform/plugins/shared/actions/server/plugin.ts
+++ b/x-pack/platform/plugins/shared/actions/server/plugin.ts
@@ -46,6 +46,7 @@ import type { ServerlessPluginSetup, ServerlessPluginStart } from '@kbn/serverle
 import type { CloudSetup } from '@kbn/cloud-plugin/server';
 import type { AxiosInstance } from 'axios';
 import type { UsageApiSetup } from '@kbn/usage-api-plugin/server';
+import type { CredentialAccessor } from '@kbn/connector-specs';
 import { type ActionsConfig, type EnabledConnectorTypes } from './config';
 import { AllowedHosts, getValidatedConfig } from './config';
 import { resolveCustomHosts } from './lib/custom_host_settings';
@@ -56,7 +57,13 @@ import { AuthTypeRegistry, registerAuthTypes } from './auth_types';
 import { createBulkExecutionEnqueuerFunction } from './create_execute_function';
 import { registerActionsUsageCollector } from './usage';
 import type { ILicenseState } from './lib';
-import { ActionExecutor, TaskRunnerFactory, LicenseState, spaceIdToNamespace } from './lib';
+import {
+  ActionExecutor,
+  TaskRunnerFactory,
+  LicenseState,
+  spaceIdToNamespace,
+  LeasePool,
+} from './lib';
 import type {
   Services,
   ActionType,
@@ -118,8 +125,8 @@ import { createSystemConnectors } from './create_system_actions';
 import { ConnectorUsageReportingTask } from './usage/connector_usage_reporting_task';
 import { ConnectorRateLimiter } from './lib/connector_rate_limiter';
 import { OAuthRateLimiter } from './lib/oauth_rate_limiter';
-import type { GetAxiosInstanceWithAuthFnOpts } from './lib/get_axios_instance';
-import { getAxiosInstanceWithAuth } from './lib/get_axios_instance';
+import type { GetAxiosInstanceWithAuthFnOpts, GetCredentialFnOpts } from './lib/get_axios_instance';
+import { getAxiosInstanceWithAuth, getCredentialWithAuth } from './lib/get_axios_instance';
 
 export interface PluginSetupContract {
   registerType<
@@ -139,6 +146,11 @@ export interface PluginSetupContract {
   ): void;
 
   getAxiosInstanceWithAuth(opts: GetAxiosInstanceWithAuthFnOpts): Promise<AxiosInstance>;
+
+  getCredential(opts: GetCredentialFnOpts): CredentialAccessor;
+
+  /** PoC: process-wide pool for reusable connector clients (MCP, future DB/gRPC). */
+  getClientLeasePool(): LeasePool<unknown>;
 
   isPreconfiguredConnector(connectorId: string): boolean;
 
@@ -272,6 +284,9 @@ export class ActionsPlugin
   private connectorUsageReportingTask: ConnectorUsageReportingTask | undefined;
   private connectorLifecycleListeners: ConnectorLifecycleListener[] = [];
   private skippedPreconfiguredConnectorIds: Set<string> = new Set();
+  // PoC: process-wide pool. Warm MCP/DB sessions must outlive a single action; the plugin
+  // instance is the owner (ActionContext dies when the action returns).
+  private clientLeasePool?: LeasePool<unknown>;
 
   constructor(initContext: PluginInitializerContext) {
     this.logger = initContext.logger.get();
@@ -482,6 +497,8 @@ export class ActionsPlugin
         actionsConfigUtils,
         plugins.cloud
       ),
+      getCredential: this.getCredentialHelper(actionsConfigUtils),
+      getClientLeasePool: () => this.clientLeasePool!,
       isPreconfiguredConnector: (connectorId: string): boolean => {
         return !!this.inMemoryConnectors.find(
           (inMemoryConnector) =>
@@ -520,6 +537,8 @@ export class ActionsPlugin
   }
 
   public start(core: CoreStart, plugins: ActionsPluginsStart): PluginStartContract {
+    this.clientLeasePool = new LeasePool<unknown>(this.logger);
+
     const {
       logger,
       licenseState,
@@ -599,6 +618,7 @@ export class ActionsPlugin
         encryptedSavedObjectsClient,
         connectorLifecycleListeners: this.connectorLifecycleListeners,
         getCurrentUserProfileId,
+        evictClientPool: (connectorId: string) => this.clientLeasePool?.evict(connectorId),
       });
     };
 
@@ -973,6 +993,7 @@ export class ActionsPlugin
       connectorLifecycleListeners,
     } = this;
     const getSkippedPreconfiguredIds = () => this.skippedPreconfiguredConnectorIds;
+    const evictClientPool = (connectorId: string) => this.clientLeasePool?.evict(connectorId);
 
     return async function actionsRouteHandlerContext(context, request) {
       const [coreStart, pluginsStart] = await core.getStartServices();
@@ -1033,6 +1054,7 @@ export class ActionsPlugin
             connectorLifecycleListeners,
             getCurrentUserProfileId: (requestWithAuth: KibanaRequest) =>
               getCurrentUserProfileIdFromRequest(requestWithAuth, pluginsStart.security, logger),
+            evictClientPool,
           });
         },
         listTypes: (featureId?: string) => {
@@ -1072,6 +1094,14 @@ export class ActionsPlugin
     };
   };
 
+  private getCredentialHelper = (actionsConfigUtils: ActionsConfigurationUtilities) => {
+    return getCredentialWithAuth({
+      authTypeRegistry: this.authTypeRegistry!,
+      configurationUtilities: actionsConfigUtils,
+      logger: this.logger,
+    });
+  };
+
   private registerDynamicConnector = (connector: InMemoryConnector): boolean => {
     if (!this.inMemoryConnectors.find((c) => c.id === connector.id)) {
       this.inMemoryConnectors.push({
@@ -1101,6 +1131,7 @@ export class ActionsPlugin
     if (this.licenseState) {
       this.licenseState.clean();
     }
+    this.clientLeasePool?.stop();
   }
 }
 


### PR DESCRIPTION
## Summary

Reproduce PoC PR #274998 onto `main`, omitting only the MCP client-type implementation. The framework lands present-but-unconsumed (empty registry); MCP source stays exactly as on `main`.

**What the change is for:** The full PoC framework is present but has **no registered client type**:

- `@kbn/connector-specs` exposes `ClientTypeSpec`, `BuildContext`, `ConnectorNetwork`, `CredentialAccessor`, `ClientRegistry` (empty), `ClientTypeId` (= `never`), and `clientTypes` (= `{}`). `ActionContext` has a typed-but-uncallable `getClient`; `AuthTypeSpec`/`BearerAuth` have `getAuthHeaders`.
- The `actions` plugin has a process-wide `LeasePool` created at `start()` and drained at `stop()`; the setup contract exposes `getCredential` and `getClientLeasePool`; `generateExecutorFunction` assembles the `BuildContext`, wires a `getClient` closure over `pool.lease` + `buildClientLeaseKey`, and classifies build failures as USER/FRAMEWORK; connector delete and update evict the connector's pool entries.
- **MCP source is byte-for-byte identical to `main`.** No DROP file is touched.
- Runtime behavior is identical to `main` because nothing calls `getClient`. The framework is proven only by fake-`ClientTypeSpec` unit tests.

**Approaches considered/ruled out:** The PoC diff itself (PR #274998) is the authoritative model for every KEEP file; reproduce shapes verbatim except the registry adaptation. Registry ships empty (module-level typed map, no runtime `register()`); `ClientTypeId = never` — intended. Package split: contract types in `@kbn/connector-specs`, runtime in `actions` plugin (forced by dep graph, same as PoC). No new deps: `lru-cache` is already a root dependency; task-manager error helpers already exported and reachable. DROP = do nothing: none of the MCP files are created/edited/deleted.

## What Changed

**Phase 1: Contract package — `@kbn/connector-specs` client-type seam (empty registry)**
- **Created** `src/lib/clients/client_type_spec.ts` — `ConnectorNetwork`, `CredentialAccessor`, `BuildContext`, `ClientTypeSpec<TClient>` interfaces
- **Created** `src/lib/clients/index.ts` — **EMPTY registry**: `ClientRegistry = {}`, `ClientTypeId = never`, `clientTypes = {}`
- **Modified** `src/connector_spec.ts` — added `getClient<K extends ClientTypeId>(id: K)` to `ActionContext`; added optional `getAuthHeaders` to `AuthTypeSpec`
- **Modified** `src/auth_types/bearer.ts` — added `getAuthHeaders` returning `{ Authorization: 'Bearer ${token}' }`
- **Created** `src/auth_types/bearer.test.ts` — tests `BearerAuth.getAuthHeaders`
- **Modified** `index.ts` — exported client types and `clientTypes`

**Phase 2: Runtime pool + seams — `LeasePool`, `ConnectorNetwork`, credential, lease key**
- **Created** `lib/lease_pool.ts` — `LeasePool<TClient>` with LRU-cache backed lease/evict/stop lifecycle
- **Created** `lib/lease_pool.test.ts` — full test suite for reuse, anti-stampede, eviction, idle TTL
- **Created** `lib/single_file_connectors/create_connector_network.ts` — `AllowlistDeniedError` and `createConnectorNetwork` delegating to config utils
- **Created** `lib/single_file_connectors/create_connector_network.test.ts` — tests delegation and error wrapping
- **Created** `lib/single_file_connectors/build_client_lease_key.ts` — `buildClientLeaseKey` generating `connectorId:clientTypeId:shared`
- **Created** `lib/single_file_connectors/build_client_lease_key.test.ts` — tests key format
- **Modified** `lib/get_axios_instance.ts` — added `UnsupportedAuthProducerError`, `GetCredentialFn`, and `getCredentialWithAuth`
- **Modified** `lib/index.ts` — exported `LeasePool`

**Phase 3: Executor wiring + BuildContext assembly (fake-client proven)**
- **Modified** `lib/single_file_connectors/generate_executor_function.ts` — extended params with `getCredential`, `getClientLeasePool`, `network`, `clientTypes`; added `getClient` closure over `pool.lease`; added USER/FRAMEWORK classification
- **Modified** `lib/single_file_connectors/create_connector_from_spec.ts` — passed new deps to `generateExecutorFunction`
- **Modified** `lib/single_file_connectors/generate_executor_function.test.ts` — extensive test suite with fake `ClientTypeSpec`s testing build/reuse, error classification, allowlist denial

**Phase 4: Plugin lifecycle + connector eviction wiring**
- **Modified** `plugin.ts` — added `getCredential`/`getClientLeasePool` to setup contract; created pool at start()/drained at stop(); wired eviction
- **Modified** `actions_client/actions_client.ts` — added `evictClientPool` to options/context; called eviction in delete()
- **Modified** `actions_client/actions_client.test.ts` — tested eviction is called on delete
- **Modified** `application/connector/methods/update/update.ts` — called eviction on update
- **Modified** `mocks.ts` — added `getCredential`/`getClientLeasePool` to setup mock

## Test Plan

**Unit tests created/modified:**
- `bearer.test.ts` — tests `BearerAuth.getAuthHeaders` returns correct Authorization header
- `lease_pool.test.ts` — tests reuse, anti-stampede, evict-on-reject, isolation, idle TTL, `evict(prefix)`, `stop()` drain
- `create_connector_network.test.ts` — tests exact keys, delegation, `AllowlistDeniedError` wrapping
- `build_client_lease_key.test.ts` — tests key format and special character preservation
- `generate_executor_function.test.ts` — extensive suite with fake `ClientTypeSpec`s testing network/credential passed to build context, build once/reuse behavior, unknown client id error handling, USER vs FRAMEWORK error classification, allowlist denial → USER classification, distinct connectorIds → distinct pool entries, pre-tagged error passthrough
- `actions_client.test.ts` — tests `evictClientPool` called with connector id on delete

**Manual verification steps:**
- Registry ships empty by design (`clientTypes = {}`)
- `getClient('any-id')` throws "Unknown client type" at runtime (matches PoC test expectation)  
- Framework proven by fake-client unit tests exercising pool/executor/network/classification
- Zero runtime effect on existing connectors (no calls to `getClient`)
- MCP untouched verification: `git diff --name-only` shows no files under MCP directories (`src/lib/mcp/`, `kbn-mcp-client/`, `kbn-mcp-dev-server/`); no `mcp_client_type*` files created/modified

**Type checking passed:**
- `node scripts/type_check --project src/platform/packages/shared/kbn-connector-specs/tsconfig.json` — `ClientTypeId = never`, `getClient` typed but uncallable
- `node scripts/type_check --project x-pack/platform/plugins/shared/actions/tsconfig.json` — all new types compile correctly

## Risk Verdict

Risk: **Medium** — process-wide connector-client pool + new error-classification/allowlist seams in a wide-blast-radius plugin (`actions`), but the runtime path is dormant (empty `ClientRegistry`) and the pool itself is well-tested.

## Review Findings

**`generate_executor_function.ts:175` [Important] USER-tagged `getClient` failures become task-retryable**
- **What:** the new `if (error instanceof Error && getErrorSource(error)) throw error;` re-throws tagged errors out of the executor. `action_executor.ts:610-619` catches *any* thrown error and sets `retry: true` regardless of source — so a USER-classified failure (MCP 401, or `AllowlistDeniedError`) gets retried, defeating the stated intent that allowlist/auth denials are "permanent bad config, cannot succeed on retry."
- **Trigger:** a registered client type whose `build()` throws a USER-classified error (exercised by tests at `generate_executor_function.test.ts:1444-1513`, which assert the USER tag but not the downstream retry).
- **Not live today:** `ClientRegistry` is `{}` and no shipping connector calls `ctx.getClient`, so this is a latent bug in the seam, not a regression to any current connector. Fix before a real client type lands: re-throw only FRAMEWORK, or return `{status:'error', retry:false, errorSource:USER}` for USER-tagged `getClient` failures.

**Action items**
- Read `generate_executor_function.ts:134-176` carefully — the `getClient` closure + error-source re-throw is the load-bearing new behavior and the one place USER/FRAMEWORK semantics can go wrong end-to-end.
- Missing test: **update-path eviction** — `update.ts:212` calls `evictClientPool` but only `delete()` has a test (`actions_client.test.ts:1966`). Add an `update()` test asserting eviction on success and none on failed write.
- Missing test: **`getCredentialWithAuth` / `UnsupportedAuthProducerError`** (`get_axios_instance.ts:322-365`) has no unit test — add bearer happy-path + unsupported-auth-throws.
- Missing test: **end-to-end retry semantics** for a USER-tagged `getClient` throw through `action_executor` → `task_runner_factory` (this is what would have caught the finding above).
- Precedent (align or document): allowlist denial is wrapped/tagged USER here but `sub_action_connector.ts:85` throws a plain i18n `Error` for the same check — two divergent shapes for the same denial. And MCP session lifetime now has three models (pooled seam vs `with_mcp_client.ts` connect-per-action vs `stack_connectors/.../mcp.ts`); pick one when wiring a real `mcp` client type.
- Scope note: the seam ships fully dormant (empty registry, no production caller). That's fine for a PoC, but nothing exercises it in production paths yet — the classification bug above will only surface once a client type is registered.

**Manual test steps**
- No manual test needed — no externally-triggerable behavior changed. The seam is unreachable from any shipping connector (empty `ClientRegistry`); everything new is exercised only via unit tests with injected client types.